### PR TITLE
Disable webuniversum vendor styles

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,6 +13,9 @@ module.exports = function(defaults) {
         'node_modules/@appuniversum/appuniversum',
         'node_modules/@appuniversum/ember-appuniversum/app/styles',
       ]
+    },
+    '@lblod/ember-vo-webuniversum': {
+      'shouldImportComponentCss': false,
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.0",
-    "@lblod/ember-vo-webuniversum": "^0.22.7",
+    "@lblod/ember-vo-webuniversum": "^0.23.0",
     "@lblod/ember-vo-webuniversum-widget": "^0.1.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
These styles are already imported in [app.scss](https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/blob/0afef31995aee20f51634d5220b7a064c4098e0d/app/styles/app.scss#L47) (and saves about 130kb unminified / uncompressed).