### PR TITLE
Fix a problem where the appuniversum icons aren't visible when deployed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:3.5.0 as builder
+FROM madnificent/ember:3.20.0 as builder
 
 LABEL maintainer="info@redpencil.io"
 
@@ -10,5 +10,5 @@ RUN ember build -prod
 
 
 FROM cecemel/ember-fastboot-proxy-service:0.9.1
-
+ENV STATIC_FOLDERS_REGEX "^/(assets|@appuniversum)/"
 COPY --from=builder /app/dist /app


### PR DESCRIPTION
Took me a while because I was derping with docker and totally forgot how to build / run images locally. :no_mouth:. It seems to work locally though! I updated the ember image while I was at it.