### PR TITLE
Feature/publication dates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,6 @@ steps:
   - npm install
 - name: lint:js
   image: danlynn/ember-cli:3.20.0
-  failure: ignore
   commands:
   - npm run lint:js
 - name: lint:hbs
@@ -18,6 +17,7 @@ steps:
   - npm run lint:hbs
 - name: lint:dependencies
   image: danlynn/ember-cli:3.20.0
+  failure: ignore
   commands:
   - ember dependency-lint
 - name: test

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,12 +14,10 @@ steps:
   - npm run lint:js
 - name: lint:hbs
   image: danlynn/ember-cli:3.20.0
-  failure: ignore
   commands:
   - npm run lint:hbs
 - name: lint:dependencies
   image: danlynn/ember-cli:3.20.0
-  failure: ignore
   commands:
   - ember dependency-lint
 - name: test

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,11 @@ steps:
   failure: ignore
   commands:
   - npm run test:ember
+---
+kind: pipeline
+type: docker
+name: build-dry-run
+steps:
 - name: build-dry-run
   image: plugins/docker
   settings:

--- a/app/components/agendapunt-overview-item.hbs
+++ b/app/components/agendapunt-overview-item.hbs
@@ -9,7 +9,7 @@
         {{#if @agendapunt.beschrijving}}
           <p property="dct:description"><span class="au-c-help-text--secondary">{{clean-spaces @agendapunt.beschrijving}}</span></p>
         {{/if}}
-        <span property="besluit:geplandOpenbaar" content="{{@agendapunt.geplandOpenbaar}}" class="au-u-hidden"></span>
+        <span property="besluit:geplandOpenbaar" content={{if @agendapunt.geplandOpenbaar "true" "false"}} class="au-u-hidden"></span>
         {{#unless this.uittreksel.inhoud}}
           <p>
             <AuHelpText @skin="secondary">Inhoud niet publiek</AuHelpText>

--- a/app/components/agendapunt-overview-item.hbs
+++ b/app/components/agendapunt-overview-item.hbs
@@ -2,13 +2,11 @@
   <div class="au-c-card__header">
     <div class="au-o-grid au-o-grid--small">
       <div class="au-o-grid__item au-u-3-4@medium">
-        <AuHeading @level="2" @skin="4" property="dct:title">{{clean-spaces @agendapunt.titel}}</</AuHeading>
+        <h2 class="au-c-heading--4" property="dct:title">{{clean-spaces @agendapunt.titel}}</</h2>
         {{#if @agendapunt.beschrijving}}
-          <p property="dct:description">
-            <AuHelpText @skin="secondary">{{clean-spaces @agendapunt.beschrijving}}</AuHelpText>
-          </p>
+          <p property="dct:description"><span class="au-c-help-text--secondary">{{clean-spaces @agendapunt.beschrijving}}</span></p>
         {{/if}}
-        <span property="besluit:geplandOpenbaar" content={{@agendapunt.geplandOpenbaar}} class="au-u-hidden"></span>
+        <span property="besluit:geplandOpenbaar" content="{{@agendapunt.geplandOpenbaar}}" class="au-u-hidden"></span>
         {{#unless this.uittreksel.inhoud}}
           <p>
             <AuHelpText @skin="secondary">Inhoud niet publiek</AuHelpText>

--- a/app/components/agendapunt-overview-item.hbs
+++ b/app/components/agendapunt-overview-item.hbs
@@ -4,7 +4,7 @@
       <div class="au-o-grid__item au-u-3-4@medium">
         <h2 class="au-c-heading--4" property="dct:title">{{clean-spaces @agendapunt.titel}}</</h2>
         {{#if @agendapunt.type}}
-          <span property="besluit:Agendapunt.type" style='display: none;' resource="{{@agendapunt.type.uri}}" typeof="skos:Concept">{{@agendapunt.type.label}}</span>
+          <span property="besluit:Agendapunt.type" class="au-u-hidden-visually" resource="{{@agendapunt.type.uri}}" typeof="skos:Concept">{{@agendapunt.type.label}}</span>
         {{/if}}
         {{#if @agendapunt.beschrijving}}
           <p property="dct:description"><span class="au-c-help-text--secondary">{{clean-spaces @agendapunt.beschrijving}}</span></p>

--- a/app/controllers/bestuurseenheid/zitting/agenda/index.js
+++ b/app/controllers/bestuurseenheid/zitting/agenda/index.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+
+export default class BestuurseenheidZittingAgendaIndexController extends Controller {
+  get sortedAgendapoints() {
+    return this.model.sortedAgendapoints;
+  }
+
+  get meeting() {
+    return this.model.meeting;
+  }
+
+  get publication() {
+    return this.model.agenda.publication;
+  }
+}

--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -1,9 +1,10 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class AgendaModel extends Model {
   @attr uri;
   @attr inhoud;
   @hasMany('agendapunt') agendapunten;
+  @belongsTo('published-resource') publication;
 
   type = 'http://data.lblod.info/id/document-types/agenda';
 

--- a/app/models/uittreksel.js
+++ b/app/models/uittreksel.js
@@ -4,7 +4,7 @@ export default class UittrekselModel extends Model {
   @attr uri;
   @attr inhoud;
   @belongsTo('behandeling-van-agendapunt') behandelingVanAgendapunt;
-
+  @belongsTo('published-resource') publication;
   type = 'http://data.lblod.info/id/document-types/uittreksel';
 
   rdfaBindings = {

--- a/app/models/zitting.js
+++ b/app/models/zitting.js
@@ -14,11 +14,7 @@ export default class ZittingModel extends Model {
   @hasMany('uittreksel') uittreksels;
   @belongsTo('besluitenlijst') besluitenlijst;
   @belongsTo('notulen') notulen;
-
   @alias('agendas.firstObject') agenda; // TODO doesn's seem to work on the template
-  agendapuntenSort = ['position'];
-  @sort('agendapunten', 'agendapuntenSort') sortedAgendapunten;
-
   rdfaBindings = {
     class: "besluit:Zitting",
     geplandeStart: {

--- a/app/models/zitting.js
+++ b/app/models/zitting.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import { alias, sort } from '@ember/object/computed';
+import { alias } from '@ember/object/computed';
 
 export default class ZittingModel extends Model {
   @attr uri;

--- a/app/routes/bestuurseenheid/zitting/uittreksels/detail.js
+++ b/app/routes/bestuurseenheid/zitting/uittreksels/detail.js
@@ -5,10 +5,7 @@ export default class BestuurseenheidZittingUittrekselsDetailRoute extends Route 
 
   model(params) {
     return this.store.findRecord('uittreksel', params.uittreksel_id, {
-      include: [
-        'behandeling-van-agendapunt.onderwerp',
-        'behandeling-van-agendapunt.besluiten'
-      ].join()
+      include: 'publication'
     });
   }
 }

--- a/app/routes/bestuurseenheid/zitting/uittreksels/detail/index.js
+++ b/app/routes/bestuurseenheid/zitting/uittreksels/detail/index.js
@@ -1,10 +1,13 @@
 import Route from '@ember/routing/route';
 
 export default class BestuurseenheidZittingUittrekselsDetailIndexRoute extends Route {
-  model() {
+  async model() {
+    const uittreksel = this.modelFor('bestuurseenheid.zitting.uittreksels.detail');
+    const publication = uittreksel.get('publication');
     return {
-      uittreksel: this.modelFor('bestuurseenheid.zitting.uittreksels.detail'),
+      uittreksel,
+      publication,
       zitting: this.modelFor('bestuurseenheid.zitting'),
-    }
+    };
   }
 }

--- a/app/templates/bestuurseenheid/zitting/agenda/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/agenda/index.hbs
@@ -15,7 +15,7 @@
     <p class="au-c-heading au-c-heading--5">
       Datum publicatie:
       {{#if this.publication.createdOn}}
-        <span property="eli:date_publication" content={{moment-format this.publication.createdon 'YYYY-MM-DD'}} datatype="xsd:date">
+        <span property="eli:date_publication" content={{moment-format this.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
           {{moment-format this.publication.createdOn 'D MMMM YYYY'}}
         </span>
       {{else}}

--- a/app/templates/bestuurseenheid/zitting/agenda/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/agenda/index.hbs
@@ -1,22 +1,31 @@
 <div class="au-o-layout">
   <a href="http://data.lblod.info/id/document-types/agenda" property="dct:type" class="au-u-hidden"></a>
-
-  <div class="au-o-region-large" typeof="besluit:Zitting" resource={{this.model.uri}}>
+  <div class="au-o-region-large" typeof="besluit:Zitting" resource={{this.meeting.uri}}>
     <AuHeading @skin="2" class="au-u-margin-bottom">
-      <span resource={{this.model.agendas.firstObject.uri}} typeof="foaf:Document" property="besluit:heeftAgenda">Agenda</span>
+      <span resource={{this.agenda.uri}} typeof="foaf:Document" property="besluit:heeftAgenda">Agenda</span>
       voor
-      <span resource={{this.model.bestuursorgaan.uri}} typeof="besluit:Bestuursorgaan" property="besluit:isGehoudenDoor">
-        <span resource={{this.model.bestuursorgaan.isTijdsspecialisatieVan.uri}} typeof="besluit:Bestuursorgaan" property="mandaat:isTijdspecialisatieVan">
-          <span property="skos:prefLabel">{{this.model.bestuursorgaan.isTijdsspecialisatieVan.naam}}</span>
+      <span resource={{this.meeting.bestuursorgaan.uri}} typeof="besluit:Bestuursorgaan" property="besluit:isGehoudenDoor">
+        <span resource={{this.meeting.bestuursorgaan.isTijdsspecialisatieVan.uri}} typeof="besluit:Bestuursorgaan" property="mandaat:isTijdspecialisatieVan">
+          <span property="skos:prefLabel">{{this.meeting.bestuursorgaan.isTijdsspecialisatieVan.naam}}</span>
         </span>
       </span>
       , zitting van
-      <span property="besluit:geplandeStart" content={{iso-date this.model.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.model.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
+      <span property="besluit:geplandeStart" content={{iso-date this.meeting.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.meeting.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
     </AuHeading>
-
+    <p class="au-c-heading au-c-heading--5">
+      Datum publicatie:
+      {{#if this.publication.createdOn}}
+        <span property="eli:date_publication" content={{moment-format this.publication.createdon 'YYYY-MM-DD'}} datatype="xsd:date">
+          {{moment-format this.publication.createdOn 'D MMMM YYYY'}}
+        </span>
+      {{else}}
+        {{!-- old data does not have this field --}}
+        ongekend
+      {{/if}}
+    </p>
     <ul class="au-c-list">
-      {{#if this.model.agendapunten.length}}
-        {{#each this.model.sortedAgendapunten as |agendapunt index|}}
+      {{#if this.sortedAgendapoints.length}}
+        {{#each this.sortedAgendapoints as |agendapunt index|}}
           <li resource={{agendapunt.uri}} typeof="besluit:Agendapunt" property="besluit:behandelt" class="au-c-list__item">
             <AgendapuntOverviewItem @agendapunt={{agendapunt}} @index={{index}} />
           </li>

--- a/app/templates/bestuurseenheid/zitting/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/index.hbs
@@ -138,14 +138,7 @@
                   {{moment-format this.agendaPublicationDate 'MMM'}}</strong>
                 {{/if}}
               </div>
-              <span class="au-u-hidden-visually">
-                {{#each this.zitting.agendas as |agenda|}}
-                <a href={{href-to "bestuurseenheid.zitting.agenda.raw" this.zitting.id}} property="lblodBesluit:linkToPublication" tabindex="-1">
-                  <span resource={{agenda.uri}} typeof="foaf:Document" property="besluit:heeftAgenda"/>
-                </a>
-                {{/each}}
-              </span>
-              <LinkTo @route="bestuurseenheid.zitting.agenda" @model={{this.zitting.id}} class="au-c-card__link">
+              <LinkTo @route="bestuurseenheid.zitting.agenda" @model={{this.zitting.id}} class="au-c-card__link" property="lblodBesluit:linkToPublication">
                 <span class="au-u-hidden-visually">Bekijk agenda</span>
                 <AuIcon @icon="nav-right" @size="large" />
               </LinkTo>

--- a/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
@@ -15,7 +15,7 @@
       <p class="au-c-heading au-c-heading--5">
         Datum publicatie:
         {{#if this.model.publication.createdOn}}
-          <span about={{this.model.uittreksel.uri}} property="eli:date_publication" content={{moment-format this.model.publication.createdon 'YYYY-MM-DD'}} datatype="xsd:date">
+          <span about={{this.model.uittreksel.uri}} property="eli:date_publication" content={{moment-format this.model.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
             {{moment-format this.model.publication.createdOn 'D MMMM YYYY'}}
           </span>
         {{else}}

--- a/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
@@ -12,7 +12,17 @@
         , zitting van
         <span property="besluit:geplandeStart" content={{iso-date this.model.zitting.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.model.zitting.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
       </AuHeading>
-
+      <p class="au-c-heading au-c-heading--5">
+        Datum publicatie:
+        {{#if this.model.publication.createdOn}}
+          <span about={{this.model.uittreksel.uri}} property="eli:date_publication" content={{moment-format this.model.publication.createdon 'YYYY-MM-DD'}} datatype="xsd:date">
+            {{moment-format this.model.publication.createdOn 'D MMMM YYYY'}}
+          </span>
+        {{else}}
+          {{!-- old data does not have this field --}}
+          ongekend
+        {{/if}}
+      </p>
       <div class="au-u-margin-top">
         {{#if this.model.uittreksel.inhoud}}
           <div property="besluit:heeftUittreksel" resource={{this.model.uittreksel.uri}} typeof="foaf:Document https://data.vlaanderen.be/id/concept/BesluitDocumentType/9d5bfaca-bbf2-49dd-a830-769f91a6377b">


### PR DESCRIPTION
included the publication date on the agenda and extracts. For the "notulen" I think it will be the cleanest to do this in the prepublisher. 

did some minor cleanup while working on this, I believe the agenda now works correctly with fastboot and the raw page is no longer needed for harvesting purposes.