### PR TITLE
move towards the new fastboot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 RUN ember build -prod
 
 
-FROM cecemel/ember-fastboot-proxy-service:0.9.1
+FROM redpencil/fastboot-app-server:1.0.0-beta.1
 ENV STATIC_FOLDERS_REGEX "^/(assets|@appuniversum)/"
 COPY --from=builder /app/dist /app

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,12 @@
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import {inject as service} from '@ember/service';
+
+export default class ApplicationAdapter extends JSONAPIAdapter {
+  @service fastboot;
+  constructor(){
+    super(...arguments);
+    if (this.fastboot.isFastBoot) {
+      this.host = window.BACKEND_URL;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-gelinkt-notuleren-publicatie",
-  "version": "0.17.4",
+  "version": "0.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17804,6 +17804,7 @@
         },
         "async-some": {
           "version": "1.0.2",
+          "resolved": false,
           "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
           "dev": true,
           "requires": {
@@ -17900,6 +17901,7 @@
         },
         "dezalgo": {
           "version": "1.0.3",
+          "resolved": false,
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
@@ -17934,6 +17936,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
+          "resolved": false,
           "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
           "dev": true,
           "requires": {
@@ -17957,6 +17960,7 @@
         },
         "fstream-npm": {
           "version": "1.0.7",
+          "resolved": false,
           "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
           "dev": true,
           "requires": {
@@ -18084,6 +18088,7 @@
         },
         "hosted-git-info": {
           "version": "2.1.4",
+          "resolved": false,
           "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg=",
           "dev": true
         },
@@ -19040,6 +19045,7 @@
         },
         "npm-package-arg": {
           "version": "4.1.0",
+          "resolved": false,
           "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
           "dev": true,
           "requires": {
@@ -19049,6 +19055,7 @@
         },
         "npm-registry-client": {
           "version": "7.0.9",
+          "resolved": false,
           "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
           "dev": true,
           "requires": {
@@ -19096,6 +19103,7 @@
         },
         "npmlog": {
           "version": "2.0.0",
+          "resolved": false,
           "integrity": "sha1-QHbCAKPdpREz5vPPBSEwEF94u98=",
           "dev": true,
           "requires": {
@@ -19393,6 +19401,7 @@
         },
         "read-package-json": {
           "version": "2.0.2",
+          "resolved": false,
           "integrity": "sha1-+6BV2jLK74Lo7/CPwMrHj8HQJ80=",
           "dev": true,
           "requires": {
@@ -19463,10 +19472,14 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "dev": true
             },
             "process-nextick-args": {
@@ -19477,6 +19490,8 @@
             },
             "string_decoder": {
               "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             },
             "util-deprecate": {
@@ -19501,6 +19516,7 @@
         },
         "realize-package-specifier": {
           "version": "3.0.1",
+          "resolved": false,
           "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
           "dev": true,
           "requires": {
@@ -19880,6 +19896,8 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
                           "dev": true
                         }
                       }
@@ -20156,6 +20174,7 @@
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
+              "resolved": false,
               "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
@@ -20268,6 +20287,7 @@
         },
         "write-file-atomic": {
           "version": "1.1.4",
+          "resolved": false,
           "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
cecemel/ember-fastboot-proxy-service is no longer maintained,
redpencil/fastboot-app-server is now preferred.

the new image works a bit differently because it assumes the frontend is behind
the dispatcher. as such it only provides a reverse proxy for fastboot but not
for any direct requests.

this is in turn means we need an application adapter to discover the fastboot
case and reroute our requests to the appriopate backend