### PR TITLE
replaced moment with date-fns + ember helper

### DIFF
--- a/app/helpers/format-date.js
+++ b/app/helpers/format-date.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { format } from 'date-fns';
+import { nl } from 'date-fns/locale';
+
+export default helper(function formatDate([date, dateFormat]/*, hash*/) {
+  try {
+    return format(date, dateFormat , {locale: nl});
+  }
+  catch(e) {
+    console.warn(`could not format date ${date} to format ${dateFormat}`,e);
+    return "";
+  }
+});

--- a/app/routes/bestuurseenheid/zitting.js
+++ b/app/routes/bestuurseenheid/zitting.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import moment from 'moment';
+import { format } from 'date-fns';
+import { nl } from 'date-fns/locale';
 
 export default class BestuurseenheidZittingRoute extends Route {
   breadCrumb = {};
@@ -14,7 +15,7 @@ export default class BestuurseenheidZittingRoute extends Route {
     const date = zitting.geplandeStart;
 
     this.breadCrumb = {
-      title: `Zitting van ${bestuursorgaanInTijd.naam}, op ${moment(date).format('D MMMM YYYY, HH:mm')}`
+      title: `Zitting van ${bestuursorgaanInTijd.naam}, op ${format(date,'d MMMM yyyy, HH:mm', { locale: nl})}`
     };
   }
 }

--- a/app/templates/bestuurseenheid/index.hbs
+++ b/app/templates/bestuurseenheid/index.hbs
@@ -23,7 +23,7 @@
                 <div class="au-c-content au-c-content--large au-o-grid__item au-u-3-4@medium">
                   <p>
                     <ctx.get @prop="geplandeStart" as |elements value|>
-                      <span {{rdfa elements}}>{{moment-format value 'D MMMM YYYY, HH:mm'}}</span>
+                      <span {{rdfa elements}}>{{format-date value 'd MMMM yyyy, HH:mm'}}</span>
                     </ctx.get>
                   </p>
                   <ul class="au-c-list-horizontal au-u-margin-top-small">

--- a/app/templates/bestuurseenheid/zitting/agenda/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/agenda/index.hbs
@@ -10,13 +10,13 @@
         </span>
       </span>
       , zitting van
-      <span property="besluit:geplandeStart" content={{iso-date this.meeting.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.meeting.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
+      <span property="besluit:geplandeStart" content={{iso-date this.meeting.geplandeStart}} datatype="xsd:dateTime">{{format-date this.meeting.geplandeStart 'd MMMM yyyy, HH:mm'}}</span>
     </AuHeading>
     <p class="au-c-heading au-c-heading--5">
       Datum publicatie:
       {{#if this.publication.createdOn}}
-        <span property="eli:date_publication" content={{moment-format this.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
-          {{moment-format this.publication.createdOn 'D MMMM YYYY'}}
+        <span property="eli:date_publication" content={{format-date this.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
+          {{format-date this.publication.createdOn 'd MMMM yyyy'}}
         </span>
       {{else}}
         {{!-- old data does not have this field --}}

--- a/app/templates/bestuurseenheid/zitting/besluitenlijst/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/besluitenlijst/index.hbs
@@ -8,12 +8,12 @@
       </span>, zitting van
       {{#if this.model.zitting.gestartOpTijdstip}}
         <span class="au-u-margin-bottom-tiny" property="prov:startedAtTime" content={{iso-date this.model.zitting.gestartOpTijdstip}} datatype="xsd:dateTime">
-          {{moment-format this.model.zitting.gestartOpTijdstip 'D MMMM YYYY, HH:mm'}}
+          {{format-date this.model.zitting.gestartOpTijdstip 'd MMMM yyyy, HH:mm'}}
         </span>
       {{else}}
         {{!-- fallback for old data --}}
         <span class="au-u-margin-bottom-tiny" property="prov:startedAtTime" content={{iso-date this.model.zitting.geplandeStart}} datatype="xsd:dateTime">
-          {{moment-format this.model.zitting.geplandeStart 'D MMMM YYYY, HH:mm'}}
+          {{format-date this.model.zitting.geplandeStart 'd MMMM yyyy, HH:mm'}}
         </span>
       {{/if}}
     </AuHeading>
@@ -30,8 +30,8 @@
         <p class="au-c-heading au-c-heading--5">
           Datum publicatie:
           {{#if this.model.besluitenlijst.publicatiedatum}}
-            <span property="eli:date_publication" content={{moment-format this.model.besluitenlijst.publicatiedatum 'YYYY-MM-DD'}} datatype="xsd:date">
-              {{moment-format this.model.besluitenlijst.publicatiedatum 'D MMMM YYYY'}}
+            <span property="eli:date_publication" content={{format-date this.model.besluitenlijst.publicatiedatum 'yyyy-MM-DD'}} datatype="xsd:date">
+              {{format-date this.model.besluitenlijst.publicatiedatum 'd MMMM yyyy'}}
             </span>
           {{else}}
             {{!-- old data does not have this field --}}

--- a/app/templates/bestuurseenheid/zitting/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/index.hbs
@@ -10,7 +10,7 @@
         </span>
         <br>
         op
-        <span property="besluit:geplandeStart" content={{iso-date this.zitting.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.zitting.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
+        <span property="besluit:geplandeStart" content={{iso-date this.zitting.geplandeStart}} datatype="xsd:dateTime">{{format-date this.zitting.geplandeStart 'd MMMM yyyy, HH:mm'}}</span>
       </AuHeading>
       <ul class="au-c-steps">
         <li class="au-c-steps__item">
@@ -23,8 +23,8 @@
                 {{#if this.notulenPublicationDate}}
                   Gepubliceerd op:
                   <strong>
-                  {{moment-format this.notulenPublicationDate 'D'}}
-                  {{moment-format this.notulenPublicationDate 'MMM'}}</strong>
+                  {{format-date this.notulenPublicationDate 'D'}}
+                  {{format-date this.notulenPublicationDate 'MMM'}}</strong>
                 {{/if}}
               </div>
               <span class="au-u-hidden-visually">
@@ -62,8 +62,8 @@
                 {{#if this.besluitenlijstPublicationDate}}
                   Gepubliceerd op:
                   <strong>
-                  {{moment-format this.besluitenlijstPublicationDate 'D'}}
-                  {{moment-format this.besluitenlijstPublicationDate 'MMM'}}</strong>
+                  {{format-date this.besluitenlijstPublicationDate 'D'}}
+                  {{format-date this.besluitenlijstPublicationDate 'MMM'}}</strong>
                 {{/if}}
               </div>
               <span class="au-u-hidden-visually">
@@ -99,8 +99,8 @@
                 {{#if this.besluitenlijstPublicationDate}}
                   Gepubliceerd op:
                   <strong>
-                  {{moment-format this.besluitenlijstPublicationDate 'D'}}
-                  {{moment-format this.besluitenlijstPublicationDate 'MMM'}}</strong>
+                  {{format-date this.besluitenlijstPublicationDate 'D'}}
+                  {{format-date this.besluitenlijstPublicationDate 'MMM'}}</strong>
                 {{/if}}
               </div>
               <span class="au-u-hidden-visually">
@@ -134,8 +134,8 @@
                 {{#if this.agendaPublicationDate}}
                   Gepubliceerd op:
                   <strong>
-                  {{moment-format this.agendaPublicationDate 'D'}}
-                  {{moment-format this.agendaPublicationDate 'MMM'}}</strong>
+                  {{format-date this.agendaPublicationDate 'D'}}
+                  {{format-date this.agendaPublicationDate 'MMM'}}</strong>
                 {{/if}}
               </div>
               <LinkTo @route="bestuurseenheid.zitting.agenda" @model={{this.zitting.id}} class="au-c-card__link" property="lblodBesluit:linkToPublication">

--- a/app/templates/bestuurseenheid/zitting/notulen.hbs
+++ b/app/templates/bestuurseenheid/zitting/notulen.hbs
@@ -7,8 +7,8 @@
         <p class="au-c-heading au-c-heading--5">
           Datum publicatie:
           {{#if this.model.notulen.publication.createdOn}}
-            <span property="eli:date_publication" content={{moment-format this.model.notulen.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
-              {{moment-format this.model.notulen.publication.createdOn 'D MMMM YYYY'}}
+            <span property="eli:date_publication" content={{format-date this.model.notulen.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
+              {{format-date this.model.notulen.publication.createdOn 'd MMMM yyyy'}}
             </span>
           {{else}}
             {{!-- old data does not have this field --}}

--- a/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/uittreksels/detail/index.hbs
@@ -10,13 +10,13 @@
           </span>
         </span>
         , zitting van
-        <span property="besluit:geplandeStart" content={{iso-date this.model.zitting.geplandeStart}} datatype="xsd:dateTime">{{moment-format this.model.zitting.geplandeStart 'D MMMM YYYY, HH:mm'}}</span>
+        <span property="besluit:geplandeStart" content={{iso-date this.model.zitting.geplandeStart}} datatype="xsd:dateTime">{{format-date this.model.zitting.geplandeStart 'd MMMM yyyy, HH:mm'}}</span>
       </AuHeading>
       <p class="au-c-heading au-c-heading--5">
         Datum publicatie:
         {{#if this.model.publication.createdOn}}
-          <span about={{this.model.uittreksel.uri}} property="eli:date_publication" content={{moment-format this.model.publication.createdOn 'YYYY-MM-DD'}} datatype="xsd:date">
-            {{moment-format this.model.publication.createdOn 'D MMMM YYYY'}}
+          <span about={{this.model.uittreksel.uri}} property="eli:date_publication" content={{format-date this.model.publication.createdOn 'yyyy-MM-DD'}} datatype="xsd:date">
+            {{format-date this.model.publication.createdOn 'd MMMM yyyy'}}
           </span>
         {{else}}
           {{!-- old data does not have this field --}}

--- a/app/templates/bestuurseenheid/zitting/uittreksels/index.hbs
+++ b/app/templates/bestuurseenheid/zitting/uittreksels/index.hbs
@@ -13,7 +13,7 @@
       </ctx.get>
       , zitting van
       <ctx.get @prop="geplandeStart" as |elements value|>
-        <span {{rdfa elements}}>{{moment-format value 'D MMMM YYYY, HH:mm'}}</span>
+        <span {{rdfa elements}}>{{format-date value 'd MMMM yyyy, HH:mm'}}</span>
       </ctx.get>
     </AuHeading>
 
@@ -35,3 +35,4 @@
 </div>
 
 {{outlet}}
+`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7457,6 +7457,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
+      "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg=="
+    },
     "date-time": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
@@ -9031,12 +9036,6 @@
         }
       }
     },
-    "ember-cli-import-polyfill": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz",
-      "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI=",
-      "dev": true
-    },
     "ember-cli-inject-live-reload": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-2.0.2.tgz",
@@ -9080,177 +9079,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz",
       "integrity": "sha1-IMtop5D+D94kiN39jvu332/nZvI=",
       "dev": true
-    },
-    "ember-cli-moment-shim": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-moment-shim/-/ember-cli-moment-shim-3.8.0.tgz",
-      "integrity": "sha512-dN5ImjrjZevEqB7xhwFXaPWwxdKGSFiR1kqy9gDVB+A5EGnhCL1uveKugcyJE/MICVhXUAHBUu6G2LFWEPF2YA==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "^2.0.0",
-        "broccoli-merge-trees": "^2.0.0",
-        "broccoli-source": "^1.1.0",
-        "broccoli-stew": "^1.5.0",
-        "chalk": "^1.1.3",
-        "ember-cli-babel": "^7.1.2",
-        "ember-cli-import-polyfill": "^0.2.0",
-        "ember-get-config": "^0.3.0",
-        "lodash.defaults": "^4.2.0",
-        "moment": "^2.19.3",
-        "moment-timezone": "^0.5.13"
-      },
-      "dependencies": {
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-source": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-          "dev": true
-        },
-        "broccoli-stew": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.6.0.tgz",
-          "integrity": "sha512-sUwCJNnYH4Na690By5xcEMAZqKgquUQnMAEuIiL3Z2k63mSw9Xg+7Ew4wCrFrMmXMcLpWjZDOm6Yqnq268N+ZQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-debug": "^0.6.1",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.1.6",
-            "broccoli-plugin": "^1.3.0",
-            "chalk": "^2.4.1",
-            "debug": "^3.1.0",
-            "ensure-posix-path": "^1.0.1",
-            "fs-extra": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "resolve": "^1.8.1",
-            "rsvp": "^4.8.3",
-            "symlink-or-copy": "^1.2.0",
-            "walk-sync": "^0.3.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "ember-cli-normalize-entity-name": {
       "version": "1.0.0",
@@ -10502,27 +10330,6 @@
       "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
       "dev": true
     },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        }
-      }
-    },
     "ember-fetch": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.0.4.tgz",
@@ -10684,50 +10491,6 @@
         "ember-cli-babel": "^7.22.1",
         "ember-modifier-manager-polyfill": "^1.2.0",
         "focus-trap": "^6.2.0"
-      }
-    },
-    "ember-get-config": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.3.0.tgz",
-      "integrity": "sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==",
-      "dev": true,
-      "requires": {
-        "broccoli-file-creator": "^1.1.1",
-        "ember-cli-babel": "^7.0.0"
-      },
-      "dependencies": {
-        "broccoli-file-creator": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz",
-          "integrity": "sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.1.0",
-            "mkdirp": "^0.5.1"
-          }
-        }
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        }
       }
     },
     "ember-href-to": {
@@ -11104,17 +10867,6 @@
         "broccoli-string-replace": "^0.1.1",
         "ember-cli-babel": "^7.0.0",
         "lodash-es": "^4.17.4"
-      }
-    },
-    "ember-macro-helpers": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-macro-helpers/-/ember-macro-helpers-4.2.2.tgz",
-      "integrity": "sha512-E46MnpjMu+ZXRw/5A1tADZKFJADGpSAcsclcaBNfV/B1aRPV3PTTnCpDvYC1wfJ4kwwUh0DRLDH/OpBv+/41pQ==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.7.3",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-test-info": "^1.0.0"
       }
     },
     "ember-math-helpers": {
@@ -11543,172 +11295,6 @@
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
-          }
-        }
-      }
-    },
-    "ember-moment": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-8.0.1.tgz",
-      "integrity": "sha512-YmhcMkH4OUwk1ynypxgWb8/O0E+v2HaZ49rk7yPbsf7EkzAyHn2tXrQPbFW4eWCKgHl+VoRoocLU9ShSIDI7qg==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^6.7.2",
-        "ember-getowner-polyfill": "^2.2.0",
-        "ember-macro-helpers": "^4.2.2"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.13.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
-          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "^0.3.13"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-source": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-          "dev": true
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
           }
         }
       }
@@ -16717,12 +16303,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
@@ -17319,15 +16899,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
-    },
-    "moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
     },
     "morgan": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "test:ember": "ember test"
   },
   "fastbootDependencies": [
-    "moment",
-    "moment-timezone"
+    "date-fns"
   ],
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "0.4.2",
@@ -46,7 +45,6 @@
     "ember-cli-fastboot": "^2.2.2",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
-    "ember-cli-moment-shim": "^3.8.0",
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
@@ -60,7 +58,6 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-moment": "^8.0.0",
     "ember-mu-transform-helpers": "~2.0.0",
     "ember-page-title": "^6.2.2",
     "ember-power-select": "^4.0.4",
@@ -87,5 +84,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "dependencies": {
+    "date-fns": "^2.22.1"
   }
 }

--- a/tests/integration/helpers/format-date-test.js
+++ b/tests/integration/helpers/format-date-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | format-date', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders the formatted date', async function(assert) {
+    this.set('inputValue', new Date("2021-07-01"));
+
+    await render(hbs`{{format-date inputValue "d MMMM yyyy"}}`);
+
+    assert.equal(this.element.textContent.trim(), '1 juli 2021');
+  });
+});

--- a/tests/integration/helpers/iso-date-test.js
+++ b/tests/integration/helpers/iso-date-test.js
@@ -8,10 +8,10 @@ module('Integration | Helper | iso-date', function(hooks) {
 
   // Replace this with your real tests.
   test('it renders', async function(assert) {
-    this.set('inputValue', '1234');
+    this.set('inputValue', new Date("2021-07-01"));
 
     await render(hbs`{{iso-date inputValue}}`);
 
-    assert.equal(this.element.textContent.trim(), '1234');
+    assert.equal(this.element.textContent.trim(), '2021-07-01T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
given that moment is somewhat deprecated and was not working correctly in fastboot I grabbed the opportunity to replace it with a more modern (and more lightweight!) library. I believe this does mean we might drop IE11 support.

This should fix the issue with fastboot rendering an error in some cases that it could not find the module "moment-timezone"