### PR TITLE
bump fastboot-app-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ COPY . .
 RUN ember build -prod
 
 
-FROM redpencil/fastboot-app-server:1.0.0-beta.3
+FROM redpencil/fastboot-app-server:1.0.0
 COPY --from=builder /app/dist /app


### PR DESCRIPTION
the previous version did not update the fastboot config in package.json leaving
us with ugly `{{ENVIRONMENT_NAME}}` placeholders in scraped pages. the latest
version should address that