### PR TITLE
Sort on proper position

### DIFF
--- a/app/components/besluitenlijst.js
+++ b/app/components/besluitenlijst.js
@@ -30,7 +30,7 @@ export default class BesluitenlijstComponent extends Component {
         size: 100
       },
       "filter[besluitenlijst][:id:]": this.args.besluitenlijst.id,
-      sort: "volgend-uit-behandeling-van-agendapunt.onderwerp.position"
+      sort: "volgend-uit-behandeling-van-agendapunt.position"
     });
 
     this.extraBesluiten = [


### PR DESCRIPTION
fixes https://binnenland.atlassian.net/browse/GN-3126

Turns it it was simply a misconfigured sort, not a data issue. When only a decision list is published, the agenda items that this query is sorting on are not available in the publication stack. However the treatments are available, and they also have a position.