### PR TITLE
Fix/voting result spaces issue

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -164,6 +164,17 @@ body {
   }
 }
 
+div[property="besluit:heeftVoorstander"] {
+  display: none;
+}
+
+[property="besluit:heeftStemming"] {
+  p:last-child {
+    margin-bottom: $au-unit;
+    margin-top: $au-unit-small;
+  }
+}
+
 
 [property="mandaat:isBestuurlijkeAliasVan"] {
   margin-right: -.4ex;

--- a/app/styles/project/template.scss
+++ b/app/styles/project/template.scss
@@ -256,7 +256,8 @@
 
 .au-c-template-list-container {
   & + p,
-  p + & {
+  p + &,
+  & + & {
     margin-top: $au-unit-small;
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "ember build --environment=production",
+    "dev": "ember serve --proxy https://publicatie.dev.gelinkt-notuleren.lblod.info",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
Fix for "When you check the publication of a decision; at the voting there's a large amount of spaces between the listed voters & the voting result. In the preview these spaces aren't visible."

This is a quick fix. When, adding div's that should not be visible we ideally should add the `au-u-hidden-visually` class to them.