### PR TITLE
Feature/GN-3787

### DIFF
--- a/app/controllers/bestuurseenheid/index.js
+++ b/app/controllers/bestuurseenheid/index.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
+
 const PAGE_SIZE = 10;
 
 const UNIT_CLASS_TO_BODY_CLASS_MAP = {
@@ -72,18 +73,21 @@ export default class BestuurseenheidIndexController extends Controller {
   queryParams = ['from', 'to', 'administrativeBodyClassURI', 'page'];
 
   get administrativeBodyClass() {
-    const selected = this.administrativeBodyClassOptions.find(
+    console.log(
+      'this.administrativeBodyClass',
+      this.administrativeBodyClassOptions
+    );
+    return this.administrativeBodyClassOptions.find(
       (record) => record.uri === this.administrativeBodyClassURI
     );
-    return selected;
   }
 
   get administrativeBodyClassOptions() {
-    const options =
+    return (
       UNIT_CLASS_TO_BODY_CLASS_MAP[
         this.bestuurseenheid.get('classificatie.uri')
-      ]; //using get because ember-data
-    return options ? options : [];
+      ] || []
+    );
   }
 
   @action

--- a/app/controllers/bestuurseenheid/index.js
+++ b/app/controllers/bestuurseenheid/index.js
@@ -73,10 +73,6 @@ export default class BestuurseenheidIndexController extends Controller {
   queryParams = ['from', 'to', 'administrativeBodyClassURI', 'page'];
 
   get administrativeBodyClass() {
-    console.log(
-      'this.administrativeBodyClass',
-      this.administrativeBodyClassOptions
-    );
     return this.administrativeBodyClassOptions.find(
       (record) => record.uri === this.administrativeBodyClassURI
     );
@@ -110,15 +106,13 @@ export default class BestuurseenheidIndexController extends Controller {
   @restartableTask
   *fetchMeetings() {
     let startDate;
+    let endDate;
     if (this.from) {
       startDate = new Date(this.from);
       startDate.setDate(startDate.getDate() - 1);
       startDate = startDate.toISOString().substring(0, 10) + 'T00:00:00';
     }
-    let endDate;
-    if (this.to) {
-      endDate = this.to + 'T00:00:00';
-    }
+    if (this.to) endDate = this.to + 'T00:00:00';
     this.model = null;
     const model = yield this.store.query('zitting', {
       include: [
@@ -134,6 +128,8 @@ export default class BestuurseenheidIndexController extends Controller {
       'filter[:lte:gestart-op-tijdstip]': endDate,
       'filter[bestuursorgaan][is-tijdsspecialisatie-van][classificatie][:uri:]':
         this.administrativeBodyClassURI,
+      'fields[zittingen]':
+        'geplande-start,gestart-op-tijdstip,notulen,bestuursorgaan,besluitenlijst,uittreksels,agendas',
       sort: '-geplande-start',
       page: {
         number: this.page || 0,

--- a/app/controllers/bestuurseenheid/index.js
+++ b/app/controllers/bestuurseenheid/index.js
@@ -130,6 +130,10 @@ export default class BestuurseenheidIndexController extends Controller {
         this.administrativeBodyClassURI,
       'fields[zittingen]':
         'geplande-start,gestart-op-tijdstip,notulen,bestuursorgaan,besluitenlijst,uittreksels,agendas',
+      'fields[notulen]': 'id',
+      'fields[besluitenlijsten]': 'id',
+      'fields[uittreksels]': 'id',
+      'fields[agendas]': 'id',
       sort: '-geplande-start',
       page: {
         number: this.page || 0,

--- a/app/templates/bestuurseenheid/index.hbs
+++ b/app/templates/bestuurseenheid/index.hbs
@@ -45,7 +45,6 @@
       <AuLoader />
     {{else}}
       {{#if this.model.length}}
-        test: {{ this.model.length }}
       <ul class="au-c-list">
       {{#each this.model as |zitting|}}
         <li class="au-c-list__item">

--- a/app/templates/bestuurseenheid/index.hbs
+++ b/app/templates/bestuurseenheid/index.hbs
@@ -45,6 +45,7 @@
       <AuLoader />
     {{else}}
       {{#if this.model.length}}
+        test: {{ this.model.length }}
       <ul class="au-c-list">
       {{#each this.model as |zitting|}}
         <li class="au-c-list__item">


### PR DESCRIPTION
Currently the meeting overview page on publication platform is fetching all content linked to the meeting. I added the **Sparse fieldsets** to limit the amount of data we are fetching. In the first image is shown how It was before:

<img width="642" alt="Screenshot 2022-11-08 at 4 14 53 PM" src="https://user-images.githubusercontent.com/115715476/200603881-cf8ae7a3-e719-4bba-b908-319071347259.png">

and on second image below, It's the new data that we are fetching:

<img width="639" alt="Screenshot 2022-11-08 at 4 15 15 PM" src="https://user-images.githubusercontent.com/115715476/200604051-b95c5a86-c8bf-4730-b0bd-e8b9ce6f6425.png">

Please let me know, If I'm missing something.
