### PR TITLE
Update ember-cli-fastboot to version 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-dependency-checker": "^3.3.1",
         "ember-cli-dependency-lint": "^2.0.0",
-        "ember-cli-fastboot": "^4.1.0",
+        "ember-cli-fastboot": "^4.1.1",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-sass": "^10.0.1",
@@ -14286,9 +14286,9 @@
       }
     },
     "node_modules/ember-cli-fastboot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-4.1.0.tgz",
-      "integrity": "sha512-OQ1+eEVK8OBh0M0KY6Rrxu2JqdAByQlY4SWzR/06cTftcDSKpUL44DTrWPs7Te4bEgQfjbic2g8AUOVw+2YvUA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-4.1.1.tgz",
+      "integrity": "sha512-9B/qJUfDVqRmZlXxP23V2AZ3hiez99DKT2cPJ0MWkjwRom/kmVJHvv5X4fxvT7MCokjOVFvzas79D5toV4GLIA==",
       "dev": true,
       "dependencies": {
         "broccoli-concat": "^4.2.5",
@@ -14301,8 +14301,8 @@
         "ember-cli-lodash-subset": "^2.0.1",
         "ember-cli-preprocess-registry": "^3.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "fastboot": "4.1.0",
-        "fastboot-express-middleware": "4.1.0",
+        "fastboot": "4.1.1",
+        "fastboot-express-middleware": "4.1.1",
         "fastboot-transform": "^0.1.3",
         "fs-extra": "^10.0.0",
         "json-stable-stringify": "^1.0.1",
@@ -22269,9 +22269,9 @@
       }
     },
     "node_modules/fastboot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-4.1.0.tgz",
-      "integrity": "sha512-NoUUiWhLS4JfrYiHmbRjqqWmzttO+6hVyt+CawsZCg79ljTGAIhPThy8cxg11yiDNiaM9EY3kocWZrCMUM7o4g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-4.1.1.tgz",
+      "integrity": "sha512-XG7YprsAuAGZrUDhmJ0NFuEP0gpWg9LZwGWSS1I5+f0ETHKPWqb4x59sN2rU1nvCEETBK70z68tLsWsl9daomg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -22287,13 +22287,13 @@
       }
     },
     "node_modules/fastboot-express-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-4.1.0.tgz",
-      "integrity": "sha512-RH/YnAn8S/CuzVsK0SLH5cVDP50R3MedqPFhf69T3z6h7LSFm12VAU2TKkqtW/N7qDs00CK1Clus2CwuzXVtWA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-4.1.1.tgz",
+      "integrity": "sha512-RzobJdJXtFLOp+QtQlRSEm4RjepprLDITyYxPzd7M8LTH9jo2COhG0NFz2LFcv9Jtqlp8IzKh/0w2+hOt7JZow==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
-        "fastboot": "4.1.0"
+        "fastboot": "4.1.1"
       },
       "engines": {
         "node": "12.* || 14.* || >=16"
@@ -28217,9 +28217,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
+      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -46257,9 +46257,9 @@
       }
     },
     "ember-cli-fastboot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-4.1.0.tgz",
-      "integrity": "sha512-OQ1+eEVK8OBh0M0KY6Rrxu2JqdAByQlY4SWzR/06cTftcDSKpUL44DTrWPs7Te4bEgQfjbic2g8AUOVw+2YvUA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-4.1.1.tgz",
+      "integrity": "sha512-9B/qJUfDVqRmZlXxP23V2AZ3hiez99DKT2cPJ0MWkjwRom/kmVJHvv5X4fxvT7MCokjOVFvzas79D5toV4GLIA==",
       "dev": true,
       "requires": {
         "broccoli-concat": "^4.2.5",
@@ -46272,8 +46272,8 @@
         "ember-cli-lodash-subset": "^2.0.1",
         "ember-cli-preprocess-registry": "^3.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "fastboot": "4.1.0",
-        "fastboot-express-middleware": "4.1.0",
+        "fastboot": "4.1.1",
+        "fastboot-express-middleware": "4.1.1",
         "fastboot-transform": "^0.1.3",
         "fs-extra": "^10.0.0",
         "json-stable-stringify": "^1.0.1",
@@ -51558,9 +51558,9 @@
       }
     },
     "fastboot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-4.1.0.tgz",
-      "integrity": "sha512-NoUUiWhLS4JfrYiHmbRjqqWmzttO+6hVyt+CawsZCg79ljTGAIhPThy8cxg11yiDNiaM9EY3kocWZrCMUM7o4g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-4.1.1.tgz",
+      "integrity": "sha512-XG7YprsAuAGZrUDhmJ0NFuEP0gpWg9LZwGWSS1I5+f0ETHKPWqb4x59sN2rU1nvCEETBK70z68tLsWsl9daomg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -51640,13 +51640,13 @@
       }
     },
     "fastboot-express-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-4.1.0.tgz",
-      "integrity": "sha512-RH/YnAn8S/CuzVsK0SLH5cVDP50R3MedqPFhf69T3z6h7LSFm12VAU2TKkqtW/N7qDs00CK1Clus2CwuzXVtWA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-4.1.1.tgz",
+      "integrity": "sha512-RzobJdJXtFLOp+QtQlRSEm4RjepprLDITyYxPzd7M8LTH9jo2COhG0NFz2LFcv9Jtqlp8IzKh/0w2+hOt7JZow==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
-        "fastboot": "4.1.0"
+        "fastboot": "4.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -55857,9 +55857,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
+      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==",
       "dev": true
     },
     "object-assign": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-dependency-lint": "^2.0.0",
-    "ember-cli-fastboot": "^4.1.0",
+    "ember-cli-fastboot": "^4.1.1",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^10.0.1",


### PR DESCRIPTION
This PR updates ember-cli-fastboot (and thus also fastboot) to version 4.1.1. This new version removes an implicit injection which is deprecated and will be removed in ember 5+