### PR TITLE
Removal/replacement of deprecated code

### DIFF
--- a/app/components/agendapunt-overview-item.js
+++ b/app/components/agendapunt-overview-item.js
@@ -23,6 +23,6 @@ export default class AgendapuntOverviewItemComponent extends Component {
       'filter[behandeling-van-agendapunt][onderwerp][id]':
         this.args.agendapunt.id,
     });
-    this.uittreksel = uittreksels.firstObject;
+    this.uittreksel = uittreksels[0];
   });
 }

--- a/app/components/besluit-overview-item.js
+++ b/app/components/besluit-overview-item.js
@@ -25,7 +25,7 @@ export default class BesluitOverviewItemComponent extends Component {
     let uittreksels = await this.store.query('uittreksel', {
       'filter[behandeling-van-agendapunt][besluiten][id]': this.args.besluit.id,
     });
-    this.uittreksel = uittreksels.firstObject;
+    this.uittreksel = uittreksels[0];
   });
 
   findStemmingen = task(async () => {

--- a/app/components/select-bestuurseenheid-naam.js
+++ b/app/components/select-bestuurseenheid-naam.js
@@ -18,8 +18,8 @@ export default class SelectBestuurseenheidNaamComponent extends Component {
     };
 
     if (search) queryParams['filter[naam]'] = search;
-    return (await this.store.query('bestuurseenheid', queryParams)).getEach(
-      'naam'
+    return (await this.store.query('bestuurseenheid', queryParams)).map(
+      (bestuurseenheid) => bestuurseenheid.naam
     );
   });
 }

--- a/app/routes/bestuurseenheid.js
+++ b/app/routes/bestuurseenheid.js
@@ -15,7 +15,7 @@ export default class BestuurseenheidRoute extends Route {
     if (bestuurseenheden.length === 0) {
       this.transitionTo('route-not-found');
     } else {
-      return bestuurseenheden.get('firstObject');
+      return bestuurseenheden[0];
     }
   }
 }

--- a/app/routes/bestuurseenheid/zitting/agenda/index.js
+++ b/app/routes/bestuurseenheid/zitting/agenda/index.js
@@ -11,7 +11,7 @@ export default class BestuurseenheidZittingAgendaIndexRoute extends Route {
       sort: '-publication.created-on',
       include: 'publication',
     });
-    const agenda = agendas.firstObject;
+    const agenda = agendas[0];
     const meeting = await this.store.findRecord('zitting', zitting.id, {
       include: 'agendapunten,bestuursorgaan',
     });

--- a/app/routes/bestuurseenheid/zitting/agenda/index.js
+++ b/app/routes/bestuurseenheid/zitting/agenda/index.js
@@ -16,7 +16,9 @@ export default class BestuurseenheidZittingAgendaIndexRoute extends Route {
       include: 'agendapunten,bestuursorgaan',
     });
     const agendapunten = await meeting.get('agendapunten');
-    const sortedAgendapoints = agendapunten.sortBy('position');
+    const sortedAgendapoints = agendapunten
+      .slice()
+      .sort((a, b) => a.position - b.position);
     return { meeting, agenda, sortedAgendapoints };
   }
 }

--- a/app/routes/bestuurseenheid/zitting/agenda/raw.js
+++ b/app/routes/bestuurseenheid/zitting/agenda/raw.js
@@ -11,6 +11,6 @@ export default class BestuurseenheidZittingAgendaRawRoute extends Route {
         size: 1,
       },
     });
-    return agendas.firstObject;
+    return agendas[0];
   }
 }

--- a/app/routes/bestuurseenheid/zitting/uittreksels/index.js
+++ b/app/routes/bestuurseenheid/zitting/uittreksels/index.js
@@ -14,7 +14,7 @@ export default class BestuurseenheidZittingUittrekselsIndexRoute extends Route {
         'uittreksels.behandeling-van-agendapunt.besluiten',
       ].join(),
     });
-    const zitting = zittingen.firstObject;
+    const zitting = zittingen[0];
     return zitting;
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,6 +14,7 @@ module.exports = function (defaults) {
     },
     '@appuniversum/ember-appuniversum': {
       disableWormholeElement: true,
+      dutchDatePickerLocalization: true,
     },
     sassOptions: {
       includePaths: [


### PR DESCRIPTION
This PR is a start in the progress of removing/replacing deprecated code. Specifically it replaces the following deprecated methods:
- the `firstObject` property by [0]
- the `sortBy` method by the `slice().sort()` combo
- the `getEach` method is replaced by the native `map` method

Additionally, this PR also adds the `dutchDatePickerLocalization` setting to `ember-cli-build.js`