### PR TITLE
GN-4426: include footer application wide

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -1,0 +1,22 @@
+<AuMainFooter>
+  <AuHeading @level="2" @skin="4">
+    Publicatie.gelinkt-notuleren.vlaanderen.be is een officiële website van de Vlaamse overheid
+  </AuHeading>
+  <AuContent @skin="small">
+    <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
+    <ul class="au-c-list-horizontal">
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legaal.disclaimer" @skin="secondary">Disclaimer</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legaal.cookieverklaring" @skin="secondary">Cookieverklaring</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legaal.toegankelijkheidsverklaring" @skin="secondary">Toegankelijkheid</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/ondertekenen-en-publiceren/register-van-bekendmakingen" @skin="secondary">Register van Bekendmakingen (beschrijving)</AuLinkExternal>
+      </li>
+    </ul>
+  </AuContent>
+</AuMainFooter>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,5 +12,4 @@
   {{/let}}
 
   {{outlet}}
-  <Footer/>
 </AuApp>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,4 +12,5 @@
   {{/let}}
 
   {{outlet}}
+  <Footer/>
 </AuApp>

--- a/app/templates/bestuurseenheid.hbs
+++ b/app/templates/bestuurseenheid.hbs
@@ -29,24 +29,5 @@
   </m.sidebar>
   <m.content @scroll={{true}}>
     {{outlet}}
-    <AuMainFooter>
-      <AuHeading @level="2" @skin="4">
-        Publicatie.gelinkt-notuleren.vlaanderen.be is een officiële website van de Vlaamse overheid
-      </AuHeading>
-      <AuContent @skin="small">
-        <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
-        <ul class="au-c-list-horizontal">
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.disclaimer" @skin="secondary">Disclaimer</AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.cookieverklaring" @skin="secondary">Cookieverklaring</AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.toegankelijkheidsverklaring" @skin="secondary">Toegankelijkheid</AuLink>
-          </li>
-        </ul>
-      </AuContent>
-    </AuMainFooter>
   </m.content>
 </AuMainContainer>

--- a/app/templates/bestuurseenheid.hbs
+++ b/app/templates/bestuurseenheid.hbs
@@ -29,5 +29,6 @@
   </m.sidebar>
   <m.content @scroll={{true}}>
     {{outlet}}
+    <Footer/>
   </m.content>
 </AuMainContainer>

--- a/app/templates/contact.hbs
+++ b/app/templates/contact.hbs
@@ -25,3 +25,4 @@
     </AuContent>
   </div>
 </section>
+<Footer/>

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -32,3 +32,4 @@
   </div>
 </div>
 {{outlet}}
+<Footer/>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -47,5 +47,6 @@
         </ul>
       </div>
     </div>
+    <Footer/>
   </m.content>
 </AuMainContainer>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -47,28 +47,5 @@
         </ul>
       </div>
     </div>
-
-    <AuMainFooter>
-      <AuHeading @level="2" @skin="4">
-        Publicatie.gelinkt-notuleren.vlaanderen.be is een officiële website van de Vlaamse overheid
-      </AuHeading>
-      <AuContent @skin="small">
-        <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
-        <ul class="au-c-list-horizontal">
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.disclaimer" @skin="secondary">Disclaimer</AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.cookieverklaring" @skin="secondary">Cookieverklaring</AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            <AuLink @route="legaal.toegankelijkheidsverklaring" @skin="secondary">Toegankelijkheid</AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/gelinkt-notuleren-handleiding/ondertekenen-en-publiceren/register-van-bekendmakingen" @skin="secondary">Register van Bekendmakingen (beschrijving)</AuLinkExternal>
-          </li>
-        </ul>
-      </AuContent>
-    </AuMainFooter>
   </m.content>
 </AuMainContainer>

--- a/app/templates/legaal.hbs
+++ b/app/templates/legaal.hbs
@@ -5,5 +5,6 @@
         {{outlet}}
       </div>
     </div>
+    <Footer/>
   </m.content>
 </AuMainContainer>


### PR DESCRIPTION
## Overview
This PR ensures that the footer with links to legal pages is shown application-wide. 
Note: the behaviour of the footer slightly changed. It is now always visible at the bottom of the screen and not only if you scroll to it.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4426?atlOrigin=eyJpIjoiOTQzZGFkMWJmZjUxNDIzMDkxMTgwNDY2ZTBhNWNlNGMiLCJwIjoiaiJ9