### PR TITLE
GN-4432: add backwards compatible zitting route which redirects to new zitting route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -31,6 +31,8 @@ Router.map(function () {
           });
         });
       });
+      // Route created for backwards compatibility, redirects to `bestuurseenheid.zittingen.zitting`
+      this.route('zitting', { path: '/:zitting_id' });
     }
   );
   this.route('contact');

--- a/app/routes/bestuurseenheid/zitting.js
+++ b/app/routes/bestuurseenheid/zitting.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+// Route created for backwards compatibility, redirects to `bestuurseenheid.zittingen.zitting`
+export default class BestuurseenheidZittingRoute extends Route {
+  @service router;
+
+  beforeModel(transition) {
+    this.router.replaceWith(
+      'bestuurseenheid.zittingen.zitting',
+      transition.to.params.zitting_id
+    );
+  }
+}


### PR DESCRIPTION
## Overview
The route structure of this application has recently changed. E.g. the page http://publicatie.gelinkt-notuleren.lblod.info/Aalst/Gemeente/635e9960-9cae-11ed-a0cb-23059201c8a7/besluitenlijst can now be found on https://publicatie.gelinkt-notuleren.lblod.info/Aalst/Gemeente/zittingen/635e9960-9cae-11ed-a0cb-23059201c8a7/besluitenlijst. This PR ensures that the previous type of URL now redirects to the new type in order to ensure that existing URLs still resolve.

This PR implements this redirect by adding a `zitting` sub-route to the `bestuurseenheid` route (`bestuurseenheid.zitting`) which redirects to the new `zitting` route (`bestuurseenheid.zittingen.zitting`)

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-4432

### How to test/reproduce
- Proxy to GN publication QA
- Visit `http://localhost:4200/Aalst/Gemeente/635e9960-9cae-11ed-a0cb-23059201c8a7` and ensure it redirects to `http://localhost:4200/Aalst/Gemeente/zittingen/635e9960-9cae-11ed-a0cb-23059201c8a7`

### Challenges/uncertainties
- This is a temporary solution in order to ensure old URLs remain resolvable, a better solution would be to use https://github.com/nvdk/cool-uris



### Checks PR readiness
- [x] npm lint