### PR TITLE
GN-4446: fix email-address formatting on error page

### DIFF
--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -27,7 +27,7 @@
   <div class="au-o-layout">
     <AuHeading @level="1" @skin="2" class="au-u-margin-bottom">Er is iets fout gelopen</AuHeading>
     <p>Er heeft zich een fout voorgedaan bij het verwerken van uw request.</p>
-    <p>Moest dit probleem aanhouden, neem contact op met <a href="mailto:Gelinkt-Notuleren@vlaanderen.be" class="au-c-link">Gelinkt-Notuleren@vlaanderen.be</a>.</p>
+    <p>Moest dit probleem aanhouden, neem contact op met <a href="mailto:gelinktnotuleren@vlaanderen.be" class="au-c-link">gelinktnotuleren@vlaanderen.be</a>.</p>
     <p><code>{{this.errorMessage}}</code></p>
   </div>
 </div>


### PR DESCRIPTION
## Overview
The wrong email address `gelinkt-notuleren@vlaanderen.be` was mentioned on the error page. This PR ensures that the email address shown is `gelinktnotuleren@vlaanderen.be`.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4446?atlOrigin=eyJpIjoiYzQ0MjdjMDE0NjllNDRlZGEzMzI4NDA5OGQzZjczYjAiLCJwIjoiaiJ9