### PR TITLE
GN-4470: fix(uittreksels): use pre-rendered extract lists

### DIFF
--- a/app/components/besluitenlijst.hbs
+++ b/app/components/besluitenlijst.hbs
@@ -1,41 +1,20 @@
 {{#if this.fastboot.isFastBoot}}
   {{html-safe @besluitenlijst.inhoud}}
 {{else}}
-  <WithRdfaContext @model={{@zitting}} as |zCtx|>
-    <AuHeading @skin="2" class="au-u-margin-bottom">Besluitenlijst van
-      <zCtx.span @prop="bestuursorgaan" as |_ boCtx|>
-        <boCtx.span @prop="isTijdsspecialisatieVan" as |_ itsvCtx|>
-          <itsvCtx.get @prop="naam" />
-        </boCtx.span>
-      </zCtx.span>
-      , zitting van
-      {{#if @zitting.gestartOpTijdstip}}
-        <zCtx.span @prop="gestartOpTijdstip" as |gestartOpTijdstip|>{{format-date gestartOpTijdstip 'd MMMM yyyy, HH:mm'}}</zCtx.span>
-      {{else}}
-        {{!-- fallback for old data --}}
-        <zCtx.span @prop="geplandeStart" as |elements geplandeStart|>{{format-date geplandeStart 'd MMMM yyyy, HH:mm'}}</zCtx.span>
+  <div class='besluitenlijst'>
+    {{html-safe this.treatedHtml.html}}
+  </div>
+
+  {{#each this.treatedHtml.decisions as |decision|}}
+    {{#let (this.getWrapper decision) as |el|}}
+      {{#if el}}
+        {{#in-element el}}
+          <DecisionLink
+            @zittingId={{@zitting.id}}
+            @decisionElement={{decision}}
+          />
+        {{/in-element}}
       {{/if}}
-    </AuHeading>
-    <ul class="au-c-list au-u-margin-top">
-      {{#each @besluiten as |besluit|}}
-        <li class="au-c-list__item">
-          <BesluitOverviewItem @besluit={{besluit}} />
-        </li>
-      {{/each}}
-      {{#each this.extraBesluiten as |besluit|}}
-        {{!-- using an extra array so the first one above renders properly with fastboot --}}
-        <li class="au-c-list__item">
-          <BesluitOverviewItem @besluit={{besluit}} />
-        </li>
-      {{/each}}
-    </ul>
-    {{#if this.fetchBesluiten.isRunning}}
-      <AuLoader />
-    {{/if}}
-    {{#if this.hasNext}}
-      <AuButton class="au-u-margin-top" {{on "click" (perform this.fetchBesluiten this.nextPage)}}>
-        Meer laden
-      </AuButton>
-    {{/if}}
-  </WithRdfaContext>
+    {{/let}}
+  {{/each}}
 {{/if}}

--- a/app/components/decision-link.hbs
+++ b/app/components/decision-link.hbs
@@ -1,0 +1,39 @@
+<div class='au-c-card__content au-u-margin-bottom-small'>
+  <div class='au-o-grid au-o-grid--small'>
+    <div class='au-o-grid__item au-u-1-4@medium'>
+      {{#if this.isLoading}}
+        <AuButton
+          @skin='button'
+          @icon='nav-right'
+          @iconAlignment='right'
+          @disabled={{true}}
+          @loading={{true}}
+        >
+          Uittreksel opvragen
+        </AuButton>
+      {{else}}
+        {{#if this.uittrekselId}}
+          <AuLink
+            @skin='button'
+            @route='bestuurseenheid.zittingen.zitting.uittreksels.detail'
+            @model={{this.uittrekselId}}
+            property='lblodBesluit:linkToPublication'
+            @icon='nav-right'
+            @iconAlignment='right'
+          >
+            Bekijk volledige inhoud
+          </AuLink>
+        {{else}}
+          <AuButton
+            @skin='button'
+            @icon='nav-right'
+            @iconAlignment='right'
+            @disabled={{true}}
+          >
+            Volledige inhoud niet publiek
+          </AuButton>
+        {{/if}}
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/app/components/decision-link.js
+++ b/app/components/decision-link.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { trackedTask } from 'ember-resources/util/ember-concurrency';
+import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+
+export default class DecisionLinkComponent extends Component {
+  @service store;
+
+  fetchPublishedExtractTask = task(async () => {
+    const uittreksels = await this.store.query('uittreksel', {
+      'filter[behandeling-van-agendapunt][besluiten][:uri:]': this.decisionURI,
+      'fields[uittreksels]': 'uri',
+    });
+    if (uittreksels.length) {
+      return uittreksels[0];
+    } else {
+      return null;
+    }
+  });
+
+  publishedExtractData = trackedTask(this, this.fetchPublishedExtractTask);
+
+  get uittrekselId() {
+    return this.publishedExtractData.value?.id;
+  }
+  get decisionURI() {
+    return this.args.decisionElement.getAttribute('resource');
+  }
+  get isLoading() {
+    return this.publishedExtractData.isRunning;
+  }
+}

--- a/app/routes/bestuurseenheid/zittingen/zitting/besluitenlijst/index.js
+++ b/app/routes/bestuurseenheid/zittingen/zitting/besluitenlijst/index.js
@@ -7,20 +7,10 @@ export default class BestuurseenheidZittingenZittingBesluitenlijstIndexRoute ext
   async model() {
     let zitting = this.modelFor('bestuurseenheid.zittingen.zitting');
     let besluitenlijst = await zitting.besluitenlijst;
-    let besluiten = await this.store.query('besluit', {
-      page: {
-        number: 0,
-        size: 100,
-      },
-      'filter[besluitenlijst][:id:]': besluitenlijst.id,
-      sort: 'volgend-uit-behandeling-van-agendapunt.position',
-      include: 'volgend-uit-behandeling-van-agendapunt',
-    });
 
     return {
       zitting,
       besluitenlijst,
-      besluiten,
     };
   }
 }

--- a/app/styles/project/publicatie.scss
+++ b/app/styles/project/publicatie.scss
@@ -6,9 +6,55 @@
 /* Style document publish for besluitenlijst, remove when fixed bug
  ========================================================================== */
 
+.besluitenlijst {
+  [typeof='besluit:BehandelingVanAgendapunt'] {
+    border: 0.1rem solid $au-gray-200;
+    padding: 2.4rem;
+    margin-top: 1.2rem;
+  }
+  [property='http://data.vlaanderen.be/ns/besluit#geplandeStart']
+  {
+    display: none;
+  }
+  [typeof='besluit:Zitting'] {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding-left: 0;
+  }
+  [property='besluit:openbaar'] {
+    display: none;
+  }
+  [property='eli:title'] {
+    border-bottom: 0.1rem solid $au-gray-200;
+    font-size: $au-h4;
+    line-height: $au-global-line-height;
+  }
+  [property='prov:generated'] {
+    border-bottom: 0;
+  }
+  [property='besluit:heeftStemming'] {
+    display: flex;
+    flex-wrap: true;
+    gap: 2rem;
+    p:last-child {
+      margin: 0;
+    }
+  }
+  .besluit-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 2rem;
+    [typeof*='besluit#Besluit'] {
+      flex-grow: 1;
+    }
+  }
+}
+
 .au-c-document-publish {
-  [typeof="besluit:BehandelingVanAgendapunt"],
-  [property="besluit:behandelt"] {
+  [typeof='besluit:BehandelingVanAgendapunt'],
+  [property='besluit:behandelt'] {
     margin-bottom: 2rem;
     display: block;
   }
@@ -19,15 +65,19 @@ Document text
 Style the text from documents here.
 ========================================================================== */
 
-  /* -------------------- list styles ------------------------- */
+/* -------------------- list styles ------------------------- */
 
 .au-c-document-publish {
   ul {
     list-style: bullet;
   }
 
-  ol:not(.bullet-list):not(.numbered-list):not(.au-c-template-list-inline):not(.au-c-template-list),
-  ul:not(.bullet-list):not(.numbered-list):not(.au-c-template-list-inline):not(.au-c-template-list) {
+  ol:not(.bullet-list):not(.numbered-list):not(.au-c-template-list-inline):not(
+      .au-c-template-list
+    ),
+  ul:not(.bullet-list):not(.numbered-list):not(.au-c-template-list-inline):not(
+      .au-c-template-list
+    ) {
     padding-left: 1.75em;
 
     > li {
@@ -45,7 +95,6 @@ Style the text from documents here.
   }
 
   ul:not(.bullet-list):not(.numbered-list) li {
-
     > ul > li {
       list-style-type: circle;
 
@@ -83,11 +132,10 @@ Style the text from documents here.
     list-style-type: decimal;
   }
 
-  [property="besluit:heeftAgenda"] > ul:not(.bullet-list) li {
+  [property='besluit:heeftAgenda'] > ul:not(.bullet-list) li {
     list-style-type: none;
   }
 }
-
 
 /* Table in editor */
 .au-c-document-publish {

--- a/app/styles/project/template.scss
+++ b/app/styles/project/template.scss
@@ -164,9 +164,7 @@
 
   [typeof="besluit:BehandelingVanAgendapunt"] {
     [property="prov:generated"]:not(:last-child) {
-      margin-bottom: $au-unit-small;
       padding-bottom: $au-unit-small;
-      border-bottom: .1rem dotted $au-gray-300;
     }
 
     [property="besluit:openbaar"]:after {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "ember-qunit": "^6.2.0",
         "ember-rdfa-helpers": "^0.7.0",
         "ember-resolver": "^10.0.0",
+        "ember-resources": "^6.4.0",
         "ember-source": "~4.8.4",
         "ember-template-lint": "^5.6.0",
         "eslint": "^7.32.0",
@@ -5092,12 +5093,12 @@
       }
     },
     "node_modules/@embroider/addon-shim": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.4.tgz",
-      "integrity": "sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.6.tgz",
+      "integrity": "sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==",
       "dev": true,
       "dependencies": {
-        "@embroider/shared-internals": "^2.0.0",
+        "@embroider/shared-internals": "^2.2.3",
         "broccoli-funnel": "^3.0.8",
         "semver": "^7.3.8"
       },
@@ -5106,12 +5107,13 @@
       }
     },
     "node_modules/@embroider/addon-shim/node_modules/@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+      "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
       "dev": true,
       "dependencies": {
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
         "js-string-escape": "^1.0.1",
@@ -5125,9 +5127,9 @@
       }
     },
     "node_modules/@embroider/addon-shim/node_modules/babel-import-util": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
-      "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
       "dev": true,
       "engines": {
         "node": ">= 12.*"
@@ -5247,9 +5249,9 @@
       }
     },
     "node_modules/@embroider/addon-shim/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6186,7 +6188,6 @@
       "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.0.2.tgz",
       "integrity": "sha512-kFWfJrS7XM0NjC5YSN0CWA9FiN0mhUvWVlQ2O7YRz/uhrO8+TVYNLst0WKELRbfCXbdI7wyYQkazNgz6FoL9CA==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/@handlebars/parser": {
@@ -13152,6 +13153,19 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ember-async-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.2.tgz",
+      "integrity": "sha512-HCnQnnPCV5A7FADoW6/e+48PVxQ1ElatxZeJJoTb2UuklMHK8CpdAvEILVC0qtEeyIEbcG/LyOIxuHK0ja63zQ==",
+      "dev": true,
+      "dependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.8.5"
+      },
+      "peerDependencies": {
+        "ember-source": ">=4.8.4"
+      }
+    },
     "node_modules/ember-auto-import": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.1.tgz",
@@ -19725,6 +19739,244 @@
         "ember-source": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ember-resources": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-6.4.0.tgz",
+      "integrity": "sha512-F5tfwhu8yRrPsMQk5nJWAZJuCi1xvGaTHp3izT+8rwuBXZSvjJAW+EapWNhKR7SYmtail9cPVwh37lcDd6HLXQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@embroider/addon-shim": "^1.2.0",
+        "@embroider/macros": "^1.12.3",
+        "ember-async-data": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@ember/test-waiters": "^3.0.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "@glint/template": "^1.0.0-beta.3 || ^1.0.0",
+        "ember-concurrency": "^2.0.0 || ^3.0.0",
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ember/test-waiters": {
+          "optional": true
+        },
+        "@glimmer/component": {
+          "optional": true
+        },
+        "ember-concurrency": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-resources/node_modules/@babel/runtime": {
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/ember-resources/node_modules/@embroider/macros": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "2.4.0",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^2.0.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-resources/node_modules/@embroider/shared-internals": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+      "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-resources/node_modules/babel-import-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/ember-resources/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-resources/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-resources/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-resources/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-resources/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-resources/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-resources/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-resources/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
+    },
+    "node_modules/ember-resources/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ember-resources/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-resources/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/ember-rfc176-data": {
@@ -39257,23 +39509,24 @@
       }
     },
     "@embroider/addon-shim": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.4.tgz",
-      "integrity": "sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.6.tgz",
+      "integrity": "sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==",
       "dev": true,
       "requires": {
-        "@embroider/shared-internals": "^2.0.0",
+        "@embroider/shared-internals": "^2.2.3",
         "broccoli-funnel": "^3.0.8",
         "semver": "^7.3.8"
       },
       "dependencies": {
         "@embroider/shared-internals": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-          "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+          "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
           "dev": true,
           "requires": {
-            "babel-import-util": "^1.1.0",
+            "babel-import-util": "^2.0.0",
+            "debug": "^4.3.2",
             "ember-rfc176-data": "^0.3.17",
             "fs-extra": "^9.1.0",
             "js-string-escape": "^1.0.1",
@@ -39284,9 +39537,9 @@
           }
         },
         "babel-import-util": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.3.0.tgz",
-          "integrity": "sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
           "dev": true
         },
         "broccoli-funnel": {
@@ -39380,9 +39633,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -40072,7 +40325,6 @@
       "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.0.2.tgz",
       "integrity": "sha512-kFWfJrS7XM0NjC5YSN0CWA9FiN0mhUvWVlQ2O7YRz/uhrO8+TVYNLst0WKELRbfCXbdI7wyYQkazNgz6FoL9CA==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "@handlebars/parser": {
@@ -45386,6 +45638,16 @@
         "ember-cli-htmlbars": "^6.0.0"
       }
     },
+    "ember-async-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.2.tgz",
+      "integrity": "sha512-HCnQnnPCV5A7FADoW6/e+48PVxQ1ElatxZeJJoTb2UuklMHK8CpdAvEILVC0qtEeyIEbcG/LyOIxuHK0ja63zQ==",
+      "dev": true,
+      "requires": {
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.8.5"
+      }
+    },
     "ember-auto-import": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.1.tgz",
@@ -50279,6 +50541,163 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.11"
+      }
+    },
+    "ember-resources": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ember-resources/-/ember-resources-6.4.0.tgz",
+      "integrity": "sha512-F5tfwhu8yRrPsMQk5nJWAZJuCi1xvGaTHp3izT+8rwuBXZSvjJAW+EapWNhKR7SYmtail9cPVwh37lcDd6HLXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.17.8",
+        "@embroider/addon-shim": "^1.2.0",
+        "@embroider/macros": "^1.12.3",
+        "ember-async-data": "^1.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.22.11",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+          "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "@embroider/macros": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+          "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
+          "dev": true,
+          "requires": {
+            "@embroider/shared-internals": "2.4.0",
+            "assert-never": "^1.2.1",
+            "babel-import-util": "^2.0.0",
+            "ember-cli-babel": "^7.26.6",
+            "find-up": "^5.0.0",
+            "lodash": "^4.17.21",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "@embroider/shared-internals": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+          "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^2.0.0",
+            "debug": "^4.3.2",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "babel-import-util": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+          "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "ember-rfc176-data": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ember-qunit": "^6.2.0",
     "ember-rdfa-helpers": "^0.7.0",
     "ember-resolver": "^10.0.0",
+    "ember-resources": "^6.4.0",
     "ember-source": "~4.8.4",
     "ember-template-lint": "^5.6.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
-------

## Overview

#### The problem

Since the dawn of time we've been fighting with ordering of lists on the publication side.
The issue is that linked data lists are very hard to work with (linked lists, without any
sort of schema validation, leads to many mistakes).

In particular, decision lists (besluitenlijsten) have been the most annoying, and until now continue
to show wrong ordering. After some data diving, it's clear that the data coming from GN is not the
issue. However, here's what happens:
- GN manages articles and treatments using position predicates, rather than the linked list
specified in the model
- it builds the (correct!) linked list upon saving
- when a decision list is published, that document contains all the treatments that have decisions
- when that publication gets to the publication stack, it is parsed back into data, and the linked
list is converted again into position markers


Now the problem arises when one of the treatments does _not_ have a decision. Unfortunately this is
a completely valid usecase. Now because we're publishing a _decision_ list, not a _treatment_ list,
treatments not containing any decisions are not included in the publication. _This is also correct!_
We'd technically be publishing private data if we'd include the treatments without decisions.

Now here's the kicker: the decisions are ordered _through_ their treatments, because the data model
does not provide and ordering on _decisions_, only on _treatments_.
This means that the treatment of a decision _after_ a treatment that didn't have a decision points
to a treatment that the publication stack (rightly) does not know about, and the chain is broken.

#### The solution


After discussion with Niels, we saw various ways around the problem. One was simply including
the position markers in the publication. This would not technically follow the model, but
since its a pure extension, that would be fine.

However, we also started realizing how insane the whole process is. This is the _publication_
platform, and we get a _publication_ from GN! Why can't we _just render it_?

And in fact, that's exactly what a scraper saw already: in fastboot mode, the server included the
raw html of the published document in the page.

As far as we could tell, the only reason for the parsing and the re-building with ember components
was interactivity: a link to the published extract's contents if it happened to exist.

So what this PR does is simply render the published html instead of all the database-parsed nonsense
and just surgically inserts the required interactivity in that html, using `in-element` modifiers.


Benefits:
- more correct: we truly render exactly what we publish
- literally impossible to have the wrong order (they'd have the wrong order in GN too since
its the exact html they've approved)
- waaaay simpler: if we use this approach on other pages, there's a chance we can almost eliminate
an entire service
- actually faster to render
- easy to deploy and test, no migrations needed

Downsides:
- html modification is inherently fragile, a small change in the published document's structure
can ruin the rendering
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

##### connected issues and PRs:
[GN-4470](https://binnenland.atlassian.net/browse/GN-4470)
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

just run it

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

either recreate the above scenario (meeting with some treatments without decisiosn)
or better yet, simply proxy to production and compare with the live version

some examples of out of order decision lists:
Gemeente Baarle-Hertog, almost all decision lists
OCMW kortenberg: almost all decision lists

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->
- since it changes the html structure of the page, scrapers may be affected, although if 
they run in fastboot that should still be the exact same. and the live page should now be more correct, if anything

- I've done my best with css and responsiveness, I think its decent enough, and even a small
improvement on the live version.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations