### PR TITLE
GN-4542: Do not allow `dependency-lint` CI step to fail

### DIFF
--- a/.changeset/lazy-trees-end.md
+++ b/.changeset/lazy-trees-end.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+GN-4542: Enable `dependency-lint` CI step

--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -18,7 +18,6 @@ steps:
     group: lint
     commands:
       - npx ember dependency-lint
-    failure: ignore
   test:
     image: danlynn/ember-cli:4.8.0
     commands:


### PR DESCRIPTION
## Overview

GN-4542: Do not allow `dependency-lint` CI step to fail

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4542


### Setup

1. Checkout

### How to test/reproduce

1. `ember dependency-lint` should return 0

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations