### PR TITLE
Don't log error object to console directly

### DIFF
--- a/.changeset/chatty-elephants-punch.md
+++ b/.changeset/chatty-elephants-punch.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Don't log object directly to avoid memory leaks

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -4,7 +4,7 @@ export default class ErrorRoute extends Route {
   // note model hooks are not called on error routes
   setupController(controller, error) {
     if (error) {
-      console.error(error);
+      console.error(JSON.stringify(error));
       controller.errorMessage = error.message;
     }
     super.setupController(...arguments);


### PR DESCRIPTION
It seems that objects which get logged to the console directly are kept
around.  This creates a memory leak which could appear on stacks running
on fastboot.

-------

## Overview

Added `JSON.stringify` around logged error.

##### connected issues and PRs:

### Setup

Should just run, did not test.

### How to test/reproduce

After testing error route, run it on production ideally.

### Challenges/uncertainties

This may be one source of memory leak on this application.  Others may exist.  We did not verify that error objects specifically also caused the memory size to increase.


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations