### PR TITLE
feat: support notulen being files

### DIFF
--- a/.changeset/bright-jobs-watch.md
+++ b/.changeset/bright-jobs-watch.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': minor
+---
+
+Support notulen content being a file

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -1,0 +1,22 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FileModel extends Model {
+  @attr name;
+  @attr format;
+  @attr size;
+  @attr extension;
+  @attr('datetime') created;
+
+  get humanReadableSize() {
+    //ripped from https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+    const bytes = this.size;
+    const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB'];
+    if (bytes == 0) return '0 byte';
+    const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+    return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+  }
+
+  get downloadLink() {
+    return `/files/${this.id}/download`;
+  }
+}

--- a/app/models/notulen.js
+++ b/app/models/notulen.js
@@ -4,9 +4,9 @@ export default class NotulenModel extends Model {
   @attr uri;
   @attr inhoud;
   @belongsTo('published-resource', { async: true, inverse: null }) publication;
+  @belongsTo('file', { async: true, inverse: null }) file;
 
   type = 'http://data.lblod.info/id/document-types/notulen';
-
   rdfaBindings = {
     class: 'foaf:Document',
     type: 'dct:type',

--- a/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
+++ b/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
@@ -6,11 +6,28 @@ export default class BestuurseenheidZittingenZittingNotulenRoute extends Route {
 
   async model() {
     const parentMeeting = this.modelFor('bestuurseenheid.zittingen.zitting');
+    // TODO seems like the extra load is maybe not needed as it should be loaded through the
+    // parent route
     const meeting = await this.store.findRecord('zitting', parentMeeting.id, {
       reload: true,
       sort: '-notulen.publication.created-on',
-      include: 'notulen,notulen.publication',
+      include: 'notulen,notulen.publication,notulen.file',
     });
-    return meeting;
+    const notulen = await meeting.notulen;
+
+
+
+    const fileMeta = await notulen.file;
+    console.log("fileMeta", fileMeta);
+    let notulenContent;
+    if (fileMeta) {
+      notulenContent = await (
+        await fetch(fileMeta.downloadLink)
+      ).text();
+
+    } else {
+      notulenContent = notulen.inhoud;
+    }
+    return {meeting, notulen, notulenContent};
   }
 }

--- a/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
+++ b/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
@@ -16,7 +16,6 @@ export default class BestuurseenheidZittingenZittingNotulenRoute extends Route {
     const notulen = await meeting.notulen;
 
     const fileMeta = await notulen.file;
-    console.log('fileMeta', fileMeta);
     let notulenContent;
     if (fileMeta) {
       notulenContent = await (await fetch(fileMeta.downloadLink)).text();

--- a/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
+++ b/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
@@ -15,19 +15,14 @@ export default class BestuurseenheidZittingenZittingNotulenRoute extends Route {
     });
     const notulen = await meeting.notulen;
 
-
-
     const fileMeta = await notulen.file;
-    console.log("fileMeta", fileMeta);
+    console.log('fileMeta', fileMeta);
     let notulenContent;
     if (fileMeta) {
-      notulenContent = await (
-        await fetch(fileMeta.downloadLink)
-      ).text();
-
+      notulenContent = await (await fetch(fileMeta.downloadLink)).text();
     } else {
       notulenContent = notulen.inhoud;
     }
-    return {meeting, notulen, notulenContent};
+    return { meeting, notulen, notulenContent };
   }
 }

--- a/app/templates/bestuurseenheid/zittingen/zitting/notulen.hbs
+++ b/app/templates/bestuurseenheid/zittingen/zitting/notulen.hbs
@@ -1,33 +1,58 @@
-{{breadcrumb "Notulen" route="bestuurseenheid.zittingen.zitting.notulen"}}
-{{#let (format-date this.model.gestartOpTijdstip 'd MMMM yyyy, HH:mm') as |startDate|}}
-  {{page-title (concat
-    "Notulen van "
-    this.model.bestuursorgaan.isTijdsspecialisatieVan.naam
-    ", zitting van "
-    startDate
-    )}}
+{{breadcrumb 'Notulen' route='bestuurseenheid.zittingen.zitting.notulen'}}
+{{#let
+  (format-date this.model.meeting.gestartOpTijdstip 'd MMMM yyyy, HH:mm')
+  as |startDate|
+}}
+  {{page-title
+    (concat
+      'Notulen van '
+      this.model.meeting.bestuursorgaan.isTijdsspecialisatieVan.naam
+      ', zitting van '
+      startDate
+    )
+  }}
 {{/let}}
-<div class="au-o-layout au-c-document-publish">
-  {{!-- template-lint-disable no-invalid-link-text --}}
-  <a class="au-u-hidden" href="http://data.lblod.info/id/document-types/notulen" property="dct:type"></a>
+<div class='au-o-layout au-c-document-publish'>
+  {{! template-lint-disable no-invalid-link-text }}
+  <a
+    class='au-u-hidden'
+    href='http://data.lblod.info/id/document-types/notulen'
+    property='dct:type'
+  ></a>
 
-  <div class="au-o-region-large">
-    <WithRdfaContext @model={{this.model}} as |ctx|>
-      <ctx.div @prop="notulen" as |notulen notctx|>
-        <p class="au-c-heading au-c-heading--5">
-          Datum publicatie:
-          {{#if this.model.notulen.publication.createdOn}}
-            <notctx.span @prop="publication" as |_ pubctx|>
-              <pubctx.span @prop="createdOn" as |createdOn|>{{format-date createdOn 'd MMMM yyyy'}}</pubctx.span>
-            </notctx.span>
-          {{else}}
-            {{!-- old data does not have this field --}}
-            ongekend
-          {{/if}}
-        </p>
-        <notctx.div @prop="inhoud" as |inhoud|>{{html-safe inhoud}}</notctx.div>
-      </ctx.div>
-    </WithRdfaContext>
+  <div class='au-o-region-large'>
+    <div
+      property='besluit:heeftNotulen'
+      typeof='foaf:document'
+      resource={{this.model.notulen.uri}}
+    >
+
+      <p class='au-c-heading au-c-heading--5'>
+        Datum publicatie:
+        {{#if this.model.notulen.publication.createdOn}}
+          <span
+            property='prov:wasDerivedFrom'
+            resource={{this.model.notulen.publication.uri}}
+            typeof='sign:PublishedResource'
+          >
+            {{#let this.model.notulen.publication.createdOn as |createdOn|}}
+              <span
+                property='eli:date_publication'
+                datatype='xsd:date'
+                content={{format-date createdOn 'yyyy-MM-dd'}}
+              >
+                {{format-date createdOn 'd MMMM yyyy'}}
+              </span>
+
+            {{/let}}
+          </span>
+        {{else}}
+          {{! old data does not have this field }}
+          ongekend
+        {{/if}}
+      </p>
+      <div property='prov:value'>{{html-safe this.model.notulenContent}}</div>
+    </div>
   </div>
 </div>
 {{outlet}}


### PR DESCRIPTION
-------

## Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
As the besluit-publicatie service is actually parsing the notulen and re-inserting the html,
but enhanced with some extra rdfa, we needed to also store _that_ version as a file, and make
this frontend compatible with that

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
https://github.com/lblod/besluit-publicatie-publish-service/pull/13
https://binnenland.atlassian.net/browse/GN-4775
https://github.com/lblod/app-gn-publicatie/pull/37

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations