### PR TITLE
GN-5622: add missing `sign` prefix

### DIFF
--- a/.changeset/hip-pears-perform.md
+++ b/.changeset/hip-pears-perform.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Add missing `sign` (`http://mu.semte.ch/vocabularies/ext/signing/`) prefix

--- a/.changeset/nasty-kangaroos-refuse.md
+++ b/.changeset/nasty-kangaroos-refuse.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Set `prefix` and `vocab` attributes using modifiers

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,8 +1,47 @@
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
 import { service } from '@ember/service';
+import { modifier } from 'ember-modifier';
 
+const PREFIXES = {
+  lblod: 'http://data.lblod.info/vocabularies/lblod/',
+  eli: 'http://data.europa.eu/eli/ontology#',
+  prov: 'http://www.w3.org/ns/prov#',
+  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
+  besluit: 'http://data.vlaanderen.be/ns/besluit#',
+  generiek: 'http://data.vlaanderen.be/ns/generiek#',
+  person: 'http://www.w3.org/ns/person#',
+  persoon: 'http://data.vlaanderen.be/ns/persoon#',
+  dct: 'http://purl.org/dc/terms/',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+  org: 'http://www.w3.org/ns/org#',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  ext: 'http://mu.semte.ch/vocabularies/ext/',
+  besluittype: 'https://data.vlaanderen.be/id/concept/BesluitType/',
+  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+};
+
+const VOCAB = 'http://data.vlaanderen.be/ns/besluit#';
 export default class ApplicationController extends Controller {
+  setPrefixes = modifier(
+    (element) => {
+      const prefixString = Object.entries(PREFIXES)
+        .map(([prefix, uri]) => {
+          return `${prefix}: ${uri}`;
+        })
+        .join(' ');
+      element.setAttribute('prefix', prefixString);
+    },
+    { eager: false }
+  );
+
+  setVocab = modifier(
+    (element) => {
+      element.setAttribute('vocab', VOCAB);
+    },
+    { eager: false }
+  );
+
   @service router;
   get environmentName() {
     return getOwner(this).resolveRegistration('config:environment')

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -19,6 +19,7 @@ const PREFIXES = {
   ext: 'http://mu.semte.ch/vocabularies/ext/',
   besluittype: 'https://data.vlaanderen.be/id/concept/BesluitType/',
   lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+  sign: 'http://mu.semte.ch/vocabularies/ext/signing/',
 };
 
 const VOCAB = 'http://data.vlaanderen.be/ns/besluit#';

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,14 +1,20 @@
-<AuApp vocab="http://data.vlaanderen.be/ns/besluit#" prefix="lblod: http://data.lblod.info/vocabularies/lblod/ eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# generiek: http://data.vlaanderen.be/ns/generiek# person: http://www.w3.org/ns/person# persoon: http://data.vlaanderen.be/ns/persoon# dct: http://purl.org/dc/terms/ skos: http://www.w3.org/2004/02/skos/core# org: http://www.w3.org/ns/org# foaf: http://xmlns.com/foaf/0.1/ ext: http://mu.semte.ch/vocabularies/ext/ besluittype: https://data.vlaanderen.be/id/concept/BesluitType/ lblodBesluit: http://lblod.data.gift/vocabularies/besluit/ ">
-  {{#let (config "environmentName") as |environmentName|}}
+<AuApp {{this.setVocab}} {{this.setPrefixes}}>
+  {{#let (config 'environmentName') as |environmentName|}}
     {{#if environmentName}}
-    <EnvironmentBanner @environmentName={{environmentName}}/>
+      <EnvironmentBanner @environmentName={{environmentName}} />
     {{/if}}
-    <AuMainHeader @brandLink="https://publicatie.gelinkt-notuleren.vlaanderen.be/" @homeRoute="index" @appTitle="publicatie.gelinkt-notuleren.vlaanderen.be" @contactRoute="contact">
-    </AuMainHeader>
-    {{page-title (concat
-      "Publicatie Gelinkt Notuleren"
-      (if environmentName (concat " - " environmentName))
-    )}}
+    <AuMainHeader
+      @brandLink='https://publicatie.gelinkt-notuleren.vlaanderen.be/'
+      @homeRoute='index'
+      @appTitle='publicatie.gelinkt-notuleren.vlaanderen.be'
+      @contactRoute='contact'
+    />
+    {{page-title
+      (concat
+        'Publicatie Gelinkt Notuleren'
+        (if environmentName (concat ' - ' environmentName))
+      )
+    }}
   {{/let}}
 
   {{outlet}}


### PR DESCRIPTION
## Overview
This PR includes two changes:
- use ember modifiers to set the `prefix` and `vocab` attributes
- add missing `sign` (`http://mu.semte.ch/vocabularies/ext/signing/`) prefix

##### connected issues and PRs:
[GN-5622](https://binnenland.atlassian.net/browse/GN-5622)

### How to test/reproduce
- Start the app
- Ensure the `prefix` and `vocab` attributes are correctly set, including the `sign` prefix

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations