### PR TITLE
Add config to allow passing a fasthost allowed host into docker image

### DIFF
--- a/.changeset/gorgeous-rules-hug.md
+++ b/.changeset/gorgeous-rules-hug.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Add config option to pass an additional ember fastboot allowed host when running in docker

--- a/config/environment.js
+++ b/config/environment.js
@@ -30,6 +30,9 @@ module.exports = function (environment) {
         'backend', //mu-semtech
         'identifier', //for some reason fastboot seems to set the host header
         //to identifier instead of backend on node 18 (we don't know if it's node related, but that's as far as we got)
+        ...('{{ADDITIONAL_FASTBOOT_HOST}}'.length !== 0
+          ? ['{{ADDITIONAL_FASTBOOT_HOST}}']
+          : []),
       ],
     },
     APP: {


### PR DESCRIPTION
## Overview
This is needed to test harvesting from a locally published document as it's necessary to use the internal alias of the server as the host and the scraper does not run JS.

##### connected issues and PRs:
A related PR for details on how to use this for testing will follow...

### Setup
See [app-publicatie PR](https://github.com/lblod/app-gn-publicatie/pull/43)

### How to test/reproduce
See [app-publicatie PR](https://github.com/lblod/app-gn-publicatie/pull/43)

### Challenges/uncertainties
It seems weird to use the templating this way...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations