### PR TITLE
Fix prefixes not being defined in fastboot context

### DIFF
--- a/.changeset/little-yaks-brake.md
+++ b/.changeset/little-yaks-brake.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Fix prefixes not rendering in fastboot

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,48 +1,8 @@
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
 import { service } from '@ember/service';
-import { modifier } from 'ember-modifier';
 
-const PREFIXES = {
-  lblod: 'http://data.lblod.info/vocabularies/lblod/',
-  eli: 'http://data.europa.eu/eli/ontology#',
-  prov: 'http://www.w3.org/ns/prov#',
-  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
-  besluit: 'http://data.vlaanderen.be/ns/besluit#',
-  generiek: 'http://data.vlaanderen.be/ns/generiek#',
-  person: 'http://www.w3.org/ns/person#',
-  persoon: 'http://data.vlaanderen.be/ns/persoon#',
-  dct: 'http://purl.org/dc/terms/',
-  skos: 'http://www.w3.org/2004/02/skos/core#',
-  org: 'http://www.w3.org/ns/org#',
-  foaf: 'http://xmlns.com/foaf/0.1/',
-  ext: 'http://mu.semte.ch/vocabularies/ext/',
-  besluittype: 'https://data.vlaanderen.be/id/concept/BesluitType/',
-  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
-  sign: 'http://mu.semte.ch/vocabularies/ext/signing/',
-};
-
-const VOCAB = 'http://data.vlaanderen.be/ns/besluit#';
 export default class ApplicationController extends Controller {
-  setPrefixes = modifier(
-    (element) => {
-      const prefixString = Object.entries(PREFIXES)
-        .map(([prefix, uri]) => {
-          return `${prefix}: ${uri}`;
-        })
-        .join(' ');
-      element.setAttribute('prefix', prefixString);
-    },
-    { eager: false }
-  );
-
-  setVocab = modifier(
-    (element) => {
-      element.setAttribute('vocab', VOCAB);
-    },
-    { eager: false }
-  );
-
   @service router;
   get environmentName() {
     return getOwner(this).resolveRegistration('config:environment')

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,9 @@
-<AuApp {{this.setVocab}} {{this.setPrefixes}}>
+{{!-- DO NOT REFACTOR THIS PREFIX AND VOCAB STRING INTO A MODIFIER --}}
+{{!-- THIS DOES NOT WORK IN FASTBOOT --}}
+<AuApp
+  prefix='lblod: http://data.lblod.info/vocabularies/lblod/ eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# generiek: http://data.vlaanderen.be/ns/generiek# person: http://www.w3.org/ns/person# persoon: http://data.vlaanderen.be/ns/persoon# dct: http://purl.org/dc/terms/ skos: http://www.w3.org/2004/02/skos/core# org: http://www.w3.org/ns/org# foaf: http://xmlns.com/foaf/0.1/ ext: http://mu.semte.ch/vocabularies/ext/ besluittype: https://data.vlaanderen.be/id/concept/BesluitType/ lblodBesluit: http://lblod.data.gift/vocabularies/besluit/ sign: http://mu.semte.ch/vocabularies/ext/signing/'
+  vocab='http://data.vlaanderen.be/ns/besluit#'
+>
   {{#let (config 'environmentName') as |environmentName|}}
     {{#if environmentName}}
       <EnvironmentBanner @environmentName={{environmentName}} />


### PR DESCRIPTION
## Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

modifiers do not run in fastboot, which is where the rdfa really matters, and due to https://github.com/emberjs/ember.js/issues/19369 we cannot set the prefix dynamically "the normal way", so we _have_ to hardcode it directly in the template

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Load a zitting overview page
right click -> show page source (NOTE: this is **different** from looking in the inspector! by looking at the page source you see what the harvester sees)
before this PR: prefixes were not defined (they should be on the app div)
after this PR: they are defined

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations