### PR TITLE
We don't correcly detect that the besluit is the latest version in history

### DIFF
--- a/.changeset/swift-ligers-kick.md
+++ b/.changeset/swift-ligers-kick.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Fix detection of latest version in history besluit

--- a/app/routes/bestuurseenheid/reglementen/history/history-reglement.js
+++ b/app/routes/bestuurseenheid/reglementen/history/history-reglement.js
@@ -21,11 +21,11 @@ export default class BestuurseenheidReglementenHistoryReglementRoute extends Rou
     const publication = await uittreksel.publication;
     const bvap = await uittreksel.behandelingVanAgendapunt;
     const besluit = (await bvap.besluiten)[0];
-    const isLinkedDecisionOf = await besluit.isLinkedDecisionOf;
+    const isLatest = latestVersion.besluit.id === besluit.id;
     return {
       uittreksel,
       publication,
-      isLatest: !isLinkedDecisionOf,
+      isLatest: isLatest,
       latestVersionId: latestVersion.uittreksel.id,
     };
   }


### PR DESCRIPTION
## Overview
At some point during the merges this got broken, and the latest version also had the banner to go to the latest version which is not correct

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5976


### Setup
None

### How to test/reproduce
Go to the history and check that the banner doesn't show anymore for the latest version

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations