### PR TITLE
Change linked decision predicate to eli:consolidates

### DIFF
--- a/.changeset/silly-cameras-explain.md
+++ b/.changeset/silly-cameras-explain.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Change linked decision predicate to eli:consolidates

--- a/app/routes/bestuurseenheid/reglementen/history.js
+++ b/app/routes/bestuurseenheid/reglementen/history.js
@@ -58,7 +58,7 @@ export default class BestuurseenheidReglementenReglementRoute extends Route {
             prov:wasDerivedFrom ?publishedResource.
           ?publishedResource dct:created ?publicationdate.
           {
-            ?uri (ext:linkedDecision)+ ?originalBesluit.
+            ?uri (eli:consolidates)+ ?originalBesluit.
           }
             UNION
           {
@@ -72,7 +72,7 @@ export default class BestuurseenheidReglementenReglementRoute extends Route {
               {
                 ${sparqlEscapeUri(
                   besluit.uri
-                )} (ext:linkedDecision)+ ?originalBesluit
+                )} (eli:consolidates)+ ?originalBesluit
               }
                 UNION
               {
@@ -80,7 +80,7 @@ export default class BestuurseenheidReglementenReglementRoute extends Route {
                 ${sparqlEscapeUri(besluit.uri)} mu:uuid ?originalBesluitId.
               }
               FILTER NOT EXISTS {
-                ?originalBesluit ext:linkedDecision ?linkedDecision.
+                ?originalBesluit eli:consolidates ?linkedDecision.
               }
           }
         }

--- a/app/routes/bestuurseenheid/reglementen/index.js
+++ b/app/routes/bestuurseenheid/reglementen/index.js
@@ -122,18 +122,18 @@ export default class BestuurseenheidReglementenIndexRoute extends Route {
           besluit:isGehoudenDoor ?adminUnit.
         ?adminUnit mandaat:isTijdspecialisatieVan ?adminUnitGeneral.
         FILTER NOT EXISTS {
-          ?linkedBesluit ext:linkedDecision ?uri.
+          ?linkedBesluit eli:consolidates ?uri.
         }
         {
-    		  ?uri (ext:linkedDecision)+ ?originalBesluit.
+    		  ?uri (eli:consolidates)+ ?originalBesluit.
           {
             SELECT DISTINCT ?originalBesluit (MAX(?publicationdate) AS ?maxDate) WHERE {
               ?originalBesluit a besluit:Besluit;
                 a ?besluitTypeOriginal.
               FILTER NOT EXISTS {
-                ?originalBesluit ext:linkedDecision ?linkedDecision.
+                ?originalBesluit eli:consolidates ?linkedDecision.
               }
-              ?uri (ext:linkedDecision)+ ?originalBesluit.
+              ?uri (eli:consolidates)+ ?originalBesluit.
               ?bvap prov:generated ?uri.
               ?uittreksel ext:uittrekselBvap ?bvap;
                 mu:uuid ?uittrekselId;
@@ -144,7 +144,7 @@ export default class BestuurseenheidReglementenIndexRoute extends Route {
   		  } UNION
         {
           FILTER NOT EXISTS {
-            ?uri ext:linkedDecision ?linkedDecision.
+            ?uri eli:consolidates ?linkedDecision.
           }
           BIND(?publicationdate AS ?maxDate)
         }


### PR DESCRIPTION
### Overview
Changed linked decision predicate to the correct one according to Niels

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6070
https://github.com/lblod/frontend-gelinkt-notuleren/pull/911
https://github.com/lblod/besluit-publicatie-publish-service/pull/17
https://github.com/lblod/app-gn-publicatie/pull/45


### Setup
Use all the connected PRs for frontend GN, besluit publish service and backend GN pub

### How to test/reproduce
Create a new decision in GN, publish it, then create another one that links to the one you first created, it should appear in the reglementen screen with the correct history

### Challenges/uncertainties
None


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
