### PR TITLE
Fix: fastboot didn't find fetch so it failed

### DIFF
--- a/.changeset/wise-foxes-remain.md
+++ b/.changeset/wise-foxes-remain.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Fix: fastboot didn't find fetch so it failed

--- a/app/utils/sparql.js
+++ b/app/utils/sparql.js
@@ -1,3 +1,4 @@
+// We have to import fetch even if it's included in the browser because fastboot doesn't find it I assume because it runs node
 import fetch from 'fetch';
 export const sparqlEscapeString = (value) =>
   '"""' + value.replace(/[\\"]/g, (match) => '\\' + match) + '"""';

--- a/app/utils/sparql.js
+++ b/app/utils/sparql.js
@@ -1,3 +1,4 @@
+import fetch from 'fetch';
 export const sparqlEscapeString = (value) =>
   '"""' + value.replace(/[\\"]/g, (match) => '\\' + match) + '"""';
 


### PR DESCRIPTION
## Overview
We had a problem where reloading the reglement page resulted in going back to the zittingen page.
This is due to fetch not being found in fastboot and failing

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
Reload the page connected to your local backend (doesn't fail on proxy unless you modify your config/fastboot.js BACKEND_URL) while you are on reglementen route or subroutes, check that it stays on the page

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations