### PR TITLE
Show missing title message if the reglement has no title

### DIFF
--- a/.changeset/old-taxis-collect.md
+++ b/.changeset/old-taxis-collect.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Handle missing titles in reglements

--- a/app/helpers/reglement-title.js
+++ b/app/helpers/reglement-title.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function reglementTitle([title] /*, hash*/) {
+  if (!title || title === '') {
+    return 'Ontbrekende titel';
+  }
+  return title;
+});

--- a/app/templates/bestuurseenheid/reglementen/history/index.hbs
+++ b/app/templates/bestuurseenheid/reglementen/history/index.hbs
@@ -39,7 +39,7 @@
       <c.body as |resource|>
           <td>
             <AuLink @route='bestuurseenheid.reglementen.history.history-reglement' @model={{resource.uittreksel.id}} property="lblodBesluit:linkToPublication" @skin="link-secondary">
-              {{resource.besluit.titel}}
+              {{reglement-title resource.besluit.titel}}
             </AuLink>
             {{#if resource.latest}}
               <AuPill @skin="success">Huidge versie</AuPill>

--- a/app/templates/bestuurseenheid/reglementen/index.hbs
+++ b/app/templates/bestuurseenheid/reglementen/index.hbs
@@ -53,7 +53,7 @@
       <c.body as |uittreksel|>
           <td>
             <AuLink @route='bestuurseenheid.reglementen.reglement' @model={{uittreksel.id}} property="lblodBesluit:linkToPublication" @skin="link-secondary">
-              {{uittreksel.besluit.titel}}
+              {{reglement-title uittreksel.besluit.titel}}
             </AuLink>
           </td>
           <td>


### PR DESCRIPTION
## Overview
While it's rare a reglement can have to title, and we should handle that, in order to do that I show missing title as the title of the reglement

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6093


### Setup
None

### How to test/reproduce
Proxy to QA enter Gemeente Wichelen and notice the first reglement now has a "missing title" title

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations