### PR TITLE
Encountered fetch error when loading notulen in a file

### DIFF
--- a/.changeset/sixty-badgers-grab.md
+++ b/.changeset/sixty-badgers-grab.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren-publicatie': patch
+---
+
+Encountered fetch error when loading notulen in a file

--- a/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
+++ b/app/routes/bestuurseenheid/zittingen/zitting/notulen.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+// We have to import fetch even if it's included in the browser because fastboot doesn't find it I assume because it runs node
+import fetch from 'fetch';
 
 export default class BestuurseenheidZittingenZittingNotulenRoute extends Route {
   @service store;


### PR DESCRIPTION
## Overview
Remember that weird fetch error with fastboot in the reglementen part, so it's also happening on the notulen, when this page loads with fastboot it doesn't find the fetch as it's prerendering on node, so you have to explicitly import it

##### connected issues and PRs:
None, maybe connected to a recent problem in PROD


### Setup
None

### How to test/reproduce
Reload the notulen page over fastboot when it contains a notulen that comes from a file, it should fail before and not now

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations